### PR TITLE
Prefer chris-testing runners for Linux workflows

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -1,0 +1,18 @@
+{
+  "defaultBranch": "fork-main",
+  "importantWorkflows": [
+    "blob-size-policy",
+    "Preview Build",
+    "Release",
+    "Upstream Merge"
+  ],
+  "qaLabels": [],
+  "deployLabels": [],
+  "healthUrls": [],
+  "relatedRepos": [],
+  "validatedThrough": [],
+  "cleanup": {
+    "deleteMergedLocalBranches": true,
+    "removeMergedCleanWorktrees": true
+  }
+}

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   metadata:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     outputs:
       tag: ${{ steps.meta.outputs.tag }}
       release_name: ${{ steps.meta.outputs.release_name }}
@@ -233,7 +233,7 @@ jobs:
   publish:
     name: Publish GitHub release
     needs: [metadata, build]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     timeout-minutes: 30
     steps:
       - name: Download workflow artifacts

--- a/.github/workflows/blob-size-policy.yml
+++ b/.github/workflows/blob-size-policy.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Blob size policy
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/issue-code.yml
+++ b/.github/workflows/issue-code.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   implement:
     name: Implement changes and open PR
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     env:
       # Consistent Cargo/rustup homes for caching across all workflows
       CARGO_HOME: ${{ github.workspace }}/.cargo-home

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -48,7 +48,7 @@ jobs:
        github.event.workflow_run.event == 'pull_request' &&
        github.event.workflow_run.conclusion == 'success')
       || (github.event_name == 'workflow_dispatch' && (inputs.type == 'preview' || !inputs.type))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       RUST_WORKSPACE_DIR: code-rs
@@ -491,7 +491,7 @@ jobs:
   dispatch_comment:
     name: Post triage comment to issue (dispatch via Code)
     if: github.event_name == 'repository_dispatch' && github.event.action == 'issue-comment'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -47,7 +47,7 @@ jobs:
         github.actor != 'zemaj')
       ||
       (github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     timeout-minutes: 30
 
     env:

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -26,7 +26,7 @@ jobs:
         github.event.pull_request.head.ref != 'upstream-merge'
       )
     name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ fromJson(matrix.runs_on) }}
     env:
       # Consistent Cargo/rustup homes for caching across all workflows
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
@@ -38,21 +38,26 @@ jobs:
       matrix:
         include:
           # Linux MUSL (static-ish) builds
-          - os: ubuntu-24.04
+          - os: linux-self-hosted
+            runs_on: '["self-hosted","Linux","X64","chris-testing"]'
             target: x86_64-unknown-linux-musl
             artifact: code-x86_64-unknown-linux-musl
           - os: ubuntu-24.04-arm
+            runs_on: '["ubuntu-24.04-arm"]'
             target: aarch64-unknown-linux-musl
             artifact: code-aarch64-unknown-linux-musl
           # macOS builds (both architectures)
           - os: macos-14
+            runs_on: '["macos-14"]'
             target: x86_64-apple-darwin
             artifact: code-x86_64-apple-darwin
           - os: macos-14
+            runs_on: '["macos-14"]'
             target: aarch64-apple-darwin
             artifact: code-aarch64-apple-darwin
           # Windows build
           - os: windows-latest
+            runs_on: '["windows-latest"]'
             target: x86_64-pc-windows-msvc
             artifact: code-x86_64-pc-windows-msvc.exe
 
@@ -101,7 +106,7 @@ jobs:
 
       # Platform tuning (lightweight)
       - name: Linux musl tuning
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.target, 'musl')
+        if: runner.os == 'Linux' && contains(matrix.target, 'musl')
         shell: bash
         run: |
           sudo apt-get update
@@ -207,7 +212,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.ref != 'upstream-merge' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     steps:
       - name: Resolve slug and next tag
         id: slug
@@ -367,7 +372,7 @@ jobs:
         needs.release.result == 'skipped' ||
         needs.release.outputs.skip == 'true'
       )
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -384,7 +389,7 @@ jobs:
       github.event.pull_request.head.ref != 'upstream-merge' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.release.outputs.skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     steps:
       - name: Resolve slug and latest tag
         id: slug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   npm-auth-check:
     name: Validate npm auth
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 5
     # Fail fast if npm auth is not usable; downstream jobs should not continue.
@@ -66,9 +66,9 @@ jobs:
   preflight-tests:
     name: Preflight Tests (Linux fast E2E)
     needs: [npm-auth-check]
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     env:
-      CARGO_TARGET_DIR: /mnt/cargo-target
+      CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
     steps:
       - name: Prepare cargo target dir on data disk
         shell: bash
@@ -163,7 +163,7 @@ jobs:
   determine-version:
     name: Determine Version
     needs: [npm-auth-check]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -223,27 +223,32 @@ jobs:
   build-binaries:
     name: Build ${{ matrix.target }}
     needs: [determine-version]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ fromJson(matrix.runs_on) }}
     strategy:
       matrix:
         include:
           # Linux builds
-          - os: ubuntu-24.04
+          - os: linux-self-hosted
+            runs_on: '["self-hosted","Linux","X64","chris-testing"]'
             target: x86_64-unknown-linux-musl
             artifact: code-x86_64-unknown-linux-musl
           - os: ubuntu-24.04-arm
+            runs_on: '["ubuntu-24.04-arm"]'
             target: aarch64-unknown-linux-musl
             artifact: code-aarch64-unknown-linux-musl
           # (GNU variants omitted to reduce asset duplication; npm defaults to musl)
           # macOS builds
           - os: macos-14
+            runs_on: '["macos-14"]'
             target: x86_64-apple-darwin
             artifact: code-x86_64-apple-darwin
           - os: macos-14
+            runs_on: '["macos-14"]'
             target: aarch64-apple-darwin
             artifact: code-aarch64-apple-darwin
           # Windows build
           - os: windows-latest
+            runs_on: '["windows-latest"]'
             target: x86_64-pc-windows-msvc
             artifact: code-x86_64-pc-windows-msvc.exe
 
@@ -309,7 +314,7 @@ jobs:
 
       # Linux GNU: use mold if available; prefer system OpenSSL
       - name: Linux (gnu) tuning
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.target, 'gnu')
+        if: runner.os == 'Linux' && contains(matrix.target, 'gnu')
         shell: bash
         run: |
           set -euo pipefail
@@ -327,7 +332,7 @@ jobs:
 
       # Linux MUSL: reliable static build via musl-gcc (no glibc symbol leaks)
       - name: Linux (musl) tuning
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.target, 'musl')
+        if: runner.os == 'Linux' && contains(matrix.target, 'musl')
         shell: bash
         run: |
           set -euo pipefail
@@ -392,7 +397,7 @@ jobs:
 
       - name: Post-build smoke (run binary) [Unix]
         if: |
-          (contains(matrix.os, 'ubuntu')  && matrix.target == 'x86_64-unknown-linux-musl') ||
+          (runner.os == 'Linux'  && matrix.target == 'x86_64-unknown-linux-musl') ||
           (matrix.os == 'ubuntu-24.04-arm' && matrix.target == 'aarch64-unknown-linux-musl') ||
           (startsWith(matrix.os, 'macos-') && matrix.target == 'aarch64-apple-darwin')
         shell: bash
@@ -436,12 +441,12 @@ jobs:
           }
 
       - name: Install zstd (Linux)
-        if: contains(matrix.os, 'ubuntu')
+        if: runner.os == 'Linux'
         shell: bash
         run: sudo apt-get update -qq && sudo apt-get install -y zstd
 
       - name: Compress artifacts (Linux dual-format)
-        if: contains(matrix.os, 'ubuntu')
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           shopt -s nullglob
@@ -490,7 +495,7 @@ jobs:
   release:
     name: Publish to npm
     needs: [determine-version, build-binaries, preflight-tests]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 30
     env:

--- a/.github/workflows/rust-release-argument-comment-lint.yml
+++ b/.github/workflows/rust-release-argument-comment-lint.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   skip:
     if: ${{ !inputs.publish }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     steps:
       - run: echo "Skipping argument-comment-lint release assets for prerelease tag"
 
@@ -30,7 +30,8 @@ jobs:
             lib_name: libargument_comment_lint@nightly-2025-09-18-aarch64-apple-darwin.dylib
             runner_binary: argument-comment-lint
             cargo_dylint_binary: cargo-dylint
-          - runner: ubuntu-24.04
+          - runner: linux-self-hosted
+            runs_on: [self-hosted, Linux, X64, chris-testing]
             target: x86_64-unknown-linux-gnu
             archive_name: argument-comment-lint-x86_64-unknown-linux-gnu.tar.gz
             lib_name: libargument_comment_lint@nightly-2025-09-18-x86_64-unknown-linux-gnu.so

--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   metadata:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     outputs:
       release_tag: ${{ steps.release_tag.outputs.release_tag }}
       v8_version: ${{ steps.v8_version.outputs.version }}
@@ -59,7 +59,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     needs: metadata
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ fromJson(matrix.runs_on) }}
     permissions:
       contents: read
       actions: read
@@ -67,10 +67,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04
+          - runner: linux-self-hosted
+            runs_on: '["self-hosted","Linux","X64","chris-testing"]'
             platform: linux_amd64_musl
             target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04-arm
+            runs_on: '["ubuntu-24.04-arm"]'
             platform: linux_arm64_musl
             target: aarch64-unknown-linux-musl
 
@@ -158,7 +160,7 @@ jobs:
     needs:
       - metadata
       - build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     permissions:
       contents: write
       actions: read

--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   precheck:
     name: Precheck (no-op gate)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     timeout-minutes: 10
     outputs:
       skip_due_to_active: ${{ steps.active_guard.outputs.skip_due_to_active }}
@@ -177,7 +177,7 @@ jobs:
   merge:
     needs: [precheck]
     if: needs.precheck.outputs.skip_due_to_active != 'true' && needs.precheck.outputs.action == 'merge'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     timeout-minutes: 45
 
     steps:
@@ -1055,7 +1055,7 @@ jobs:
     name: Open/Update PR (no merge work)
     needs: [precheck]
     if: needs.precheck.outputs.skip_due_to_active != 'true' && needs.precheck.outputs.action == 'pr_only'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     timeout-minutes: 10
     steps:
       - name: Check out repository (full history)

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   metadata:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, chris-testing]
     outputs:
       v8_version: ${{ steps.v8_version.outputs.version }}
 
@@ -35,7 +35,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     needs: metadata
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ fromJson(matrix.runs_on) }}
     permissions:
       contents: read
       actions: read
@@ -43,10 +43,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04
+          - runner: linux-self-hosted
+            runs_on: '["self-hosted","Linux","X64","chris-testing"]'
             platform: linux_amd64_musl
             target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04-arm
+            runs_on: '["ubuntu-24.04-arm"]'
             platform: linux_arm64_musl
             target: aarch64-unknown-linux-musl
 


### PR DESCRIPTION
## Summary
- Move Linux/admin workflow jobs to the online chris-testing self-hosted runner.
- Keep macOS, Windows, and Linux ARM jobs on hosted runners where no matching local runner exists.
- Add .github/github-repo-workflow.json metadata.

## Validation
- GitHub reports chris-testing-code online with self-hosted/Linux/X64/chris-testing labels
- ruby YAML parse for changed workflows
- actionlint with expected custom label and pre-existing workflow warnings ignored
- ./build-fast.sh passed from the pre-commit hook