### PR TITLE
fix(core): scope Responses WebSocket reuse to turns

### DIFF
--- a/code-rs/core/src/client.rs
+++ b/code-rs/core/src/client.rs
@@ -687,6 +687,7 @@ impl ModelClient {
     /// the provider config.  Public callers always invoke `stream()` – the
     /// specialised helpers are private to avoid accidental misuse.
     pub async fn stream(&self, prompt: &Prompt) -> Result<ResponseStream> {
+        self.reset_responses_websocket_session().await;
         let env_log_tag = std::env::var("CODE_DEBUG_LOG_TAG").ok();
         let log_tag = env_log_tag
             .as_deref()
@@ -1262,6 +1263,8 @@ impl ModelClient {
                 loop {
                     let Some(next) = ws_stream.next().await else {
                         session.connection = None;
+                        session.last_request = None;
+                        session.last_response_id = None;
                         break;
                     };
                     match next {


### PR DESCRIPTION
## Summary
- reset reusable Responses WebSocket state at the start of each model turn
- clear cached chained request/response state when a WebSocket closes before a terminal response
- keep prewarm/reuse within a turn while avoiding stale cross-turn sockets

## Validation
- ./build-fast.sh