### PR TITLE
Trace remote inbox startup diagnostics

### DIFF
--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -30247,7 +30247,12 @@ Have we met every part of this goal and is there no further work to do?"#
     }
 
     fn start_remote_inbox_if_needed(&mut self, session_id: uuid::Uuid) {
-        if self.remote_inbox_client.is_some() || !self.config.remote_inbox.enabled {
+        if self.remote_inbox_client.is_some() {
+            tracing::debug!("remote inbox client already started");
+            return;
+        }
+        if !self.config.remote_inbox.enabled {
+            tracing::info!("remote inbox disabled for this session");
             return;
         }
 
@@ -30255,6 +30260,18 @@ Have we met every part of this goal and is there no further work to do?"#
             session_id.to_string(),
             chrono::Utc::now().timestamp_millis().to_string(),
             self.config.cwd.clone(),
+        );
+        tracing::info!(
+            session_id = %session.session_id,
+            cwd = %session.cwd,
+            branch = session.branch.as_deref().unwrap_or(""),
+            bridge_url_configured = self
+                .config
+                .remote_inbox
+                .bridge_url
+                .as_deref()
+                .is_some_and(|url| !url.trim().is_empty()),
+            "starting remote inbox client"
         );
         self.remote_inbox_client = crate::remote_inbox::spawn_remote_inbox_client(
             self.config.remote_inbox.clone(),

--- a/code-rs/tui/src/remote_inbox/client.rs
+++ b/code-rs/tui/src/remote_inbox/client.rs
@@ -509,6 +509,7 @@ pub(crate) fn spawn_remote_inbox_client(
     app_event_tx: AppEventSender,
 ) -> Option<RemoteInboxClientHandle> {
     if !config.enabled {
+        tracing::info!("remote inbox client spawn skipped because it is disabled");
         return None;
     }
 
@@ -522,6 +523,12 @@ pub(crate) fn spawn_remote_inbox_client(
         .clone()
         .filter(|url| !url.trim().is_empty())
     {
+        let bridge_endpoint = redact_bridge_url_for_logs(&bridge_url);
+        tracing::info!(
+            session_id = %session_id,
+            bridge_endpoint = %bridge_endpoint,
+            "spawning websocket remote inbox client"
+        );
         sinks.push(spawn_websocket_remote_inbox_client(
             bridge_url,
             config.clone(),
@@ -567,7 +574,12 @@ fn spawn_websocket_remote_inbox_client(
             )
             .await
             {
-                tracing::warn!("remote inbox connection ended: {err}");
+                let bridge_endpoint = redact_bridge_url_for_logs(&bridge_url);
+                tracing::warn!(
+                    session_id = %session.session_id,
+                    bridge_endpoint = %bridge_endpoint,
+                    "remote inbox connection ended: {err}"
+                );
             }
             tokio::time::sleep(RECONNECT_DELAY).await;
         }
@@ -870,7 +882,12 @@ async fn connect_once(
     }
 
     let (ws, _) = connect_async(request).await?;
-    tracing::info!("remote inbox connected");
+    let bridge_endpoint = redact_bridge_url_for_logs(bridge_url);
+    tracing::info!(
+        session_id = %session.session_id,
+        bridge_endpoint = %bridge_endpoint,
+        "remote inbox connected"
+    );
     let (mut write, mut read) = ws.split();
 
     send_json(&mut write, &ClientMessage::Hello(session.hello(config))).await?;
@@ -955,6 +972,19 @@ async fn connect_once(
     }
 
     Ok(())
+}
+
+fn redact_bridge_url_for_logs(bridge_url: &str) -> String {
+    match url::Url::parse(bridge_url) {
+        Ok(mut url) => {
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            url.set_query(None);
+            url.set_fragment(None);
+            url.to_string()
+        }
+        Err(_) => "<invalid bridge_url>".to_string(),
+    }
 }
 
 async fn send_latest_status_snapshot_if_idle<S>(


### PR DESCRIPTION
## Summary
- salvage the abandoned remote inbox diagnostics diff from the stale worktree
- trace disabled/already-started startup paths and websocket spawn/connect/reconnect events
- redact bridge URLs in logs to avoid recording userinfo, query strings, or fragments

## Validation
- ./build-fast.sh