### PR TITLE
Remove validatedThrough metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -57,21 +57,8 @@
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
-  "relatedRepos": ["code-everywhere"],
-  "validatedThrough": [
-    {
-      "date": "2026-05-10",
-      "source": "cbusillo/code#38",
-      "checks": [
-        "jq empty .github/github.json",
-        "rg github-repo-workflow\\.json",
-        "codex-skills github-repo-snapshot.sh --json",
-        "GitHub Actions Blob size policy"
-      ],
-      "caveats": [
-        "Validation was metadata-focused; expensive Rust workspace gates were not rerun for this metadata-only change."
-      ]
-    }
+  "relatedRepos": [
+    "code-everywhere"
   ],
   "githubSignals": {
     "postMerge": {


### PR DESCRIPTION
## Summary
- remove `validatedThrough` from `.github/github.json`
- keep repo metadata focused on current static facts and freshness triggers
- leave validation/history evidence in GitHub PRs, issues, Actions, Launchplane records, or generated reports rather than tracked config

## Validation
- `jq empty .github/github.json`
- `jq -e 'has("validatedThrough") | not' .github/github.json`
- `rg validatedThrough` over `.github`, `AGENTS.md`, `README.md`, and `docs`
- `git diff --check`

Follow-up to cbusillo/codex-skills#33.
