### PR TITLE
Clear inherited gh config in code exec harness

### DIFF
--- a/tools/code-exec-harness/harness.py
+++ b/tools/code-exec-harness/harness.py
@@ -539,6 +539,7 @@ def run_scenario(path: Path, args: argparse.Namespace) -> int:
         "XDG_CONFIG_HOME": str(paths.shell_home / ".config"),
         "ZDOTDIR": str(paths.shell_home),
     })
+    env.pop("GH_CONFIG_DIR", None)
     env.update(inherited_env)
     for key, value in scenario.get("env", {}).items():
         env[str(key)] = str(value)


### PR DESCRIPTION
## Summary
- clear inherited `GH_CONFIG_DIR` from isolated harness runs
- preserve the sandboxed copied `GH_CONFIG_DIR` only when auth inheritance requested it

## Validation
- `python3 -m py_compile tools/code-exec-harness/harness.py`
- forced outer `GH_CONFIG_DIR` smoke confirmed non-auth runs drop it
- `./build-fast.sh`
