### PR TITLE
Compact image-heavy history before reuse

### DIFF
--- a/code-rs/core/src/codex/session.rs
+++ b/code-rs/core/src/codex/session.rs
@@ -1579,7 +1579,19 @@ impl Session {
     /// history with additional items for this turn.
     /// Browser screenshots are filtered out from history to keep them ephemeral.
     pub fn turn_input_with_history(&self, extra: Vec<ResponseItem>) -> Vec<ResponseItem> {
+        self.turn_input_with_history_preserving_latest(extra, false)
+    }
+
+    pub fn turn_input_with_history_preserving_latest(
+        &self,
+        extra: Vec<ResponseItem>,
+        preserve_latest_history_item: bool,
+    ) -> Vec<ResponseItem> {
         let history = self.state.lock().unwrap().history.contents();
+        let history = crate::history_compaction::compact_response_items_for_model_history(
+            history,
+            preserve_latest_history_item,
+        );
 
         // Debug: Count function call outputs in history
         let fc_output_count = history

--- a/code-rs/core/src/codex/streaming.rs
+++ b/code-rs/core/src/codex/streaming.rs
@@ -2576,7 +2576,7 @@ async fn run_agent(
             }
             review_history.clone()
         } else {
-            sess.turn_input_with_history(pending_input_tail.clone())
+            sess.turn_input_with_history_preserving_latest(pending_input_tail.clone(), true)
         };
 
         let turn_input_messages: Vec<String> = turn_input

--- a/code-rs/core/src/history_compaction.rs
+++ b/code-rs/core/src/history_compaction.rs
@@ -2,6 +2,8 @@ use code_protocol::models::ContentItem;
 use code_protocol::models::FunctionCallOutputContentItem;
 use code_protocol::models::FunctionCallOutputPayload;
 use code_protocol::models::ResponseItem;
+use code_protocol::protocol::EventMsg as ProtoEventMsg;
+use code_protocol::protocol::UserMessageEvent;
 
 use crate::truncate::truncate_middle;
 
@@ -72,6 +74,17 @@ pub(crate) fn compact_response_items_for_model_history(
         .collect()
 }
 
+pub(crate) fn compact_protocol_event_msg_for_rollout_storage(
+    msg: ProtoEventMsg,
+) -> ProtoEventMsg {
+    match msg {
+        ProtoEventMsg::UserMessage(user_msg) => {
+            ProtoEventMsg::UserMessage(compact_user_message_event(user_msg))
+        }
+        other => other,
+    }
+}
+
 /// Compact items before writing them to rollout storage.
 ///
 /// Rollouts are replayed into future sessions, so they should keep useful
@@ -120,6 +133,14 @@ fn compact_message_content(content: Vec<ContentItem>) -> Vec<ContentItem> {
             },
         })
         .collect()
+}
+
+fn compact_user_message_event(mut event: UserMessageEvent) -> UserMessageEvent {
+    event.message = truncate_text(event.message, HISTORY_TEXT_CONTENT_MAX_BYTES);
+    if let Some(images) = event.images.take() {
+        event.images = Some(images.into_iter().map(compact_image_url).collect());
+    }
+    event
 }
 
 fn image_generation_placeholder(
@@ -310,6 +331,25 @@ mod tests {
             ResponseItem::Message { content, .. }
                 if matches!(content.first(), Some(ContentItem::InputImage { image_url })
                     if image_url == &current_image_url)
+        ));
+    }
+
+    #[test]
+    fn rollout_storage_replaces_user_message_event_images() {
+        let msg = ProtoEventMsg::UserMessage(UserMessageEvent {
+            message: "see screenshot".to_string(),
+            images: Some(vec![large_data_image()]),
+            local_images: vec![],
+            text_elements: vec![],
+        });
+
+        let compacted = compact_protocol_event_msg_for_rollout_storage(msg);
+        assert!(matches!(
+            compacted,
+            ProtoEventMsg::UserMessage(UserMessageEvent { images: Some(images), .. })
+                if images.len() == 1
+                    && images[0].contains("image omitted from reusable history")
+                    && !images[0].contains("data:image")
         ));
     }
 }

--- a/code-rs/core/src/history_compaction.rs
+++ b/code-rs/core/src/history_compaction.rs
@@ -1,0 +1,315 @@
+use code_protocol::models::ContentItem;
+use code_protocol::models::FunctionCallOutputContentItem;
+use code_protocol::models::FunctionCallOutputPayload;
+use code_protocol::models::ResponseItem;
+
+use crate::truncate::truncate_middle;
+
+const HISTORY_TOOL_OUTPUT_MAX_BYTES: usize = 4 * 1024;
+const HISTORY_TEXT_CONTENT_MAX_BYTES: usize = 8 * 1024;
+const HISTORY_IMAGE_URL_MAX_BYTES: usize = 512;
+
+/// Compact items that are being replayed as reusable model history.
+///
+/// Current-turn input is appended separately, so this can strip old tool image
+/// payloads without making fresh screenshots or user images unusable.
+pub(crate) fn compact_response_item_for_model_history(item: ResponseItem) -> ResponseItem {
+    match item {
+        ResponseItem::FunctionCallOutput { call_id, output } => ResponseItem::FunctionCallOutput {
+            call_id,
+            output: compact_tool_output_payload(output),
+        },
+        ResponseItem::CustomToolCallOutput {
+            call_id,
+            name,
+            output,
+        } => ResponseItem::CustomToolCallOutput {
+            call_id,
+            name,
+            output: compact_tool_output_payload(output),
+        },
+        ResponseItem::ImageGenerationCall {
+            status,
+            revised_prompt,
+            result,
+            ..
+        } => image_generation_placeholder(status, revised_prompt, result),
+        ResponseItem::Message {
+            id,
+            role,
+            content,
+            end_turn,
+            phase,
+        } => ResponseItem::Message {
+            id,
+            role,
+            content: compact_message_content(content),
+            end_turn,
+            phase,
+        },
+        other => other,
+    }
+}
+
+pub(crate) fn compact_response_items_for_model_history(
+    items: Vec<ResponseItem>,
+    preserve_latest: bool,
+) -> Vec<ResponseItem> {
+    let preserve_index = preserve_latest
+        .then(|| items.len().checked_sub(1))
+        .flatten();
+
+    items
+        .into_iter()
+        .enumerate()
+        .map(|(index, item)| {
+            if Some(index) == preserve_index {
+                item
+            } else {
+                compact_response_item_for_model_history(item)
+            }
+        })
+        .collect()
+}
+
+/// Compact items before writing them to rollout storage.
+///
+/// Rollouts are replayed into future sessions, so they should keep useful
+/// context while never pinning raw base64 images or huge outputs to disk.
+pub(crate) fn compact_response_item_for_rollout_storage(item: ResponseItem) -> ResponseItem {
+    compact_response_item_for_model_history(item)
+}
+
+fn compact_tool_output_payload(output: FunctionCallOutputPayload) -> FunctionCallOutputPayload {
+    let success = output.success;
+    let text = match output.content_items() {
+        Some(items) => compact_tool_output_content_items(items),
+        None => output.to_string(),
+    };
+    let text = truncate_text(text, HISTORY_TOOL_OUTPUT_MAX_BYTES);
+    let mut output = FunctionCallOutputPayload::from_text(text);
+    output.success = success;
+    output
+}
+
+fn compact_tool_output_content_items(items: &[FunctionCallOutputContentItem]) -> String {
+    items
+        .iter()
+        .map(|item| match item {
+            FunctionCallOutputContentItem::InputText { text } => {
+                truncate_text(text.clone(), HISTORY_TEXT_CONTENT_MAX_BYTES)
+            }
+            FunctionCallOutputContentItem::InputImage { image_url, .. } => compact_image_url(image_url.clone()),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compact_message_content(content: Vec<ContentItem>) -> Vec<ContentItem> {
+    content
+        .into_iter()
+        .map(|item| match item {
+            ContentItem::InputText { text } => ContentItem::InputText {
+                text: truncate_text(text, HISTORY_TEXT_CONTENT_MAX_BYTES),
+            },
+            ContentItem::OutputText { text } => ContentItem::OutputText {
+                text: truncate_text(text, HISTORY_TEXT_CONTENT_MAX_BYTES),
+            },
+            ContentItem::InputImage { image_url } => ContentItem::InputText {
+                text: compact_image_url(image_url),
+            },
+        })
+        .collect()
+}
+
+fn image_generation_placeholder(
+    status: String,
+    revised_prompt: Option<String>,
+    result: String,
+) -> ResponseItem {
+    let bytes = result.len();
+    let mut text =
+        format!("[image generation result omitted from reusable history; status={status}; {bytes} bytes]");
+    if let Some(revised_prompt) = revised_prompt {
+        text.push_str("\nRevised prompt: ");
+        text.push_str(&truncate_text(revised_prompt, HISTORY_TEXT_CONTENT_MAX_BYTES));
+    }
+
+    ResponseItem::Message {
+        id: None,
+        role: "assistant".to_string(),
+        content: vec![ContentItem::OutputText { text }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
+fn compact_image_url(image_url: String) -> String {
+    if image_url.starts_with("data:") || image_url.len() > HISTORY_IMAGE_URL_MAX_BYTES {
+        let bytes = image_url.len();
+        format!("[image omitted from reusable history; {bytes} bytes]")
+    } else {
+        image_url
+    }
+}
+
+fn truncate_text(text: String, max_bytes: usize) -> String {
+    truncate_middle(&text, max_bytes).0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use code_protocol::models::FunctionCallOutputBody;
+
+    fn large_data_image() -> String {
+        format!("data:image/png;base64,{}", "A".repeat(8 * 1024))
+    }
+
+    #[test]
+    fn model_history_replaces_tool_output_images_with_placeholders() {
+        let item = ResponseItem::FunctionCallOutput {
+            call_id: "call_1".to_string(),
+            output: FunctionCallOutputPayload::from_content_items(vec![
+                FunctionCallOutputContentItem::InputText {
+                    text: "visible context".to_string(),
+                },
+                FunctionCallOutputContentItem::InputImage {
+                    image_url: large_data_image(),
+                    detail: None,
+                },
+            ]),
+        };
+
+        let compacted = compact_response_item_for_model_history(item);
+        let ResponseItem::FunctionCallOutput { output, .. } = compacted else {
+            panic!("expected function call output");
+        };
+
+        let serialized = output.to_string();
+        assert!(serialized.contains("visible context"));
+        assert!(serialized.contains("image omitted from reusable history"));
+        assert!(!serialized.contains("data:image"));
+        assert!(!matches!(output.body, FunctionCallOutputBody::ContentItems(_)));
+    }
+
+    #[test]
+    fn model_history_truncates_large_tool_text() {
+        let item = ResponseItem::CustomToolCallOutput {
+            call_id: "call_1".to_string(),
+            name: None,
+            output: FunctionCallOutputPayload::from_text("x".repeat(16 * 1024)),
+        };
+
+        let compacted = compact_response_item_for_model_history(item);
+        let ResponseItem::CustomToolCallOutput { output, .. } = compacted else {
+            panic!("expected custom tool call output");
+        };
+
+        assert!(output.to_string().len() < 5 * 1024);
+    }
+
+    #[test]
+    fn model_history_replaces_message_images_after_current_turn() {
+        let image_url = large_data_image();
+        let item = ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputImage {
+                image_url: image_url.clone(),
+            }],
+            end_turn: None,
+            phase: None,
+        };
+
+        let compacted = compact_response_item_for_model_history(item);
+        assert!(matches!(
+            compacted,
+            ResponseItem::Message { content, .. }
+                if matches!(content.first(), Some(ContentItem::InputText { text })
+                    if text.contains("image omitted from reusable history") && !text.contains("data:image"))
+        ));
+    }
+
+    #[test]
+    fn rollout_storage_replaces_message_images() {
+        let item = ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputImage {
+                image_url: large_data_image(),
+            }],
+            end_turn: None,
+            phase: None,
+        };
+
+        let compacted = compact_response_item_for_rollout_storage(item);
+        assert!(matches!(
+            compacted,
+            ResponseItem::Message { content, .. }
+                if matches!(content.first(), Some(ContentItem::InputText { text })
+                    if text.contains("image omitted from reusable history") && !text.contains("data:image"))
+        ));
+    }
+
+    #[test]
+    fn image_generation_result_becomes_text_placeholder() {
+        let item = ResponseItem::ImageGenerationCall {
+            id: "ig_1".to_string(),
+            status: "completed".to_string(),
+            revised_prompt: Some("draw a compact image".to_string()),
+            result: "A".repeat(8 * 1024),
+        };
+
+        let compacted = compact_response_item_for_model_history(item);
+        assert!(matches!(
+            compacted,
+            ResponseItem::Message { role, content, .. }
+                if role == "assistant"
+                    && matches!(content.first(), Some(ContentItem::OutputText { text })
+                        if text.contains("image generation result omitted")
+                            && text.contains("draw a compact image"))
+        ));
+    }
+
+    #[test]
+    fn model_history_can_preserve_latest_item_for_active_turn() {
+        let old_image = ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputImage {
+                image_url: large_data_image(),
+            }],
+            end_turn: None,
+            phase: None,
+        };
+        let current_image_url = large_data_image();
+        let current_image = ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputImage {
+                image_url: current_image_url.clone(),
+            }],
+            end_turn: None,
+            phase: None,
+        };
+
+        let compacted = compact_response_items_for_model_history(
+            vec![old_image, current_image],
+            true,
+        );
+
+        assert!(matches!(
+            &compacted[0],
+            ResponseItem::Message { content, .. }
+                if matches!(content.first(), Some(ContentItem::InputText { text })
+                    if text.contains("image omitted from reusable history"))
+        ));
+        assert!(matches!(
+            &compacted[1],
+            ResponseItem::Message { content, .. }
+                if matches!(content.first(), Some(ContentItem::InputImage { image_url })
+                    if image_url == &current_image_url)
+        ));
+    }
+}

--- a/code-rs/core/src/lib.rs
+++ b/code-rs/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod config_profile;
 pub mod config_types;
 mod config_loader;
 mod conversation_history;
+mod history_compaction;
 pub mod context_timeline;
 pub mod acp;
 pub mod custom_prompts;

--- a/code-rs/core/src/rollout/recorder.rs
+++ b/code-rs/core/src/rollout/recorder.rs
@@ -219,7 +219,11 @@ impl RolloutRecorder {
         let mut rollout_items: Vec<RolloutItem> = Vec::new();
         for item in items {
             if should_persist_response_item(item) {
-                rollout_items.push(RolloutItem::ResponseItem(item.clone()));
+                rollout_items.push(RolloutItem::ResponseItem(
+                    crate::history_compaction::compact_response_item_for_rollout_storage(
+                        item.clone(),
+                    ),
+                ));
             }
         }
         if rollout_items.is_empty() {
@@ -232,7 +236,7 @@ impl RolloutRecorder {
         let mut filtered: Vec<RolloutItem> = Vec::new();
         for item in items {
             if should_persist_rollout_item(item) {
-                filtered.push(item.clone());
+                filtered.push(compact_rollout_item_for_storage(item.clone()));
             }
         }
         if filtered.is_empty() {
@@ -427,6 +431,26 @@ impl RolloutRecorder {
                 )))
             }
         }
+    }
+}
+
+fn compact_rollout_item_for_storage(item: RolloutItem) -> RolloutItem {
+    match item {
+        RolloutItem::ResponseItem(response_item) => RolloutItem::ResponseItem(
+            crate::history_compaction::compact_response_item_for_rollout_storage(response_item),
+        ),
+        RolloutItem::Compacted(mut compacted) => {
+            if let Some(replacement_history) = compacted.replacement_history.take() {
+                compacted.replacement_history = Some(
+                    replacement_history
+                        .into_iter()
+                        .map(crate::history_compaction::compact_response_item_for_rollout_storage)
+                        .collect(),
+                );
+            }
+            RolloutItem::Compacted(compacted)
+        }
+        other => other,
     }
 }
 

--- a/code-rs/core/src/rollout/recorder.rs
+++ b/code-rs/core/src/rollout/recorder.rs
@@ -219,11 +219,7 @@ impl RolloutRecorder {
         let mut rollout_items: Vec<RolloutItem> = Vec::new();
         for item in items {
             if should_persist_response_item(item) {
-                rollout_items.push(RolloutItem::ResponseItem(
-                    crate::history_compaction::compact_response_item_for_rollout_storage(
-                        item.clone(),
-                    ),
-                ));
+                rollout_items.push(RolloutItem::ResponseItem(item.clone()));
             }
         }
         if rollout_items.is_empty() {
@@ -260,7 +256,11 @@ impl RolloutRecorder {
             if event_msg_from_protocol(&event.msg)
                 .is_some_and(|msg| crate::rollout::policy::should_persist_event_msg(&msg))
             {
-                filtered.push(RolloutItem::Event(event.clone()));
+                let mut event = event.clone();
+                event.msg = crate::history_compaction::compact_protocol_event_msg_for_rollout_storage(
+                    event.msg,
+                );
+                filtered.push(RolloutItem::Event(event));
             }
         }
         if filtered.is_empty() {

--- a/code-rs/core/src/rollout/tests.rs
+++ b/code-rs/core/src/rollout/tests.rs
@@ -17,12 +17,14 @@ use uuid::Uuid;
 
 use crate::config::{Config, ConfigOverrides, ConfigToml};
 use crate::rollout::INTERACTIVE_SESSION_SOURCES;
+use crate::rollout::RolloutRecorderParams;
 use crate::rollout::list::ConversationsPage;
 use crate::rollout::list::Cursor;
 use crate::rollout::list::get_conversation;
 use crate::rollout::list::get_conversations;
 use std::time::{Duration, SystemTime};
 use code_protocol::models::{ContentItem, ResponseItem};
+use code_protocol::ConversationId;
 use code_protocol::ThreadId;
 use code_protocol::protocol::{
     EventMsg as ProtoEventMsg,
@@ -163,6 +165,53 @@ fn write_session_file(
         writer.write_all(b"\n")?;
     }
     Ok((dt, uuid))
+}
+
+#[tokio::test]
+async fn record_events_compacts_user_message_images_before_rollout_storage() {
+    let temp = TempDir::new().unwrap();
+    let code_home = temp.path();
+    let workspace = code_home.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    let mut overrides = ConfigOverrides::default();
+    overrides.cwd = Some(workspace);
+    let config = Config::load_from_base_config_with_overrides(
+        ConfigToml::default(),
+        overrides,
+        code_home.to_path_buf(),
+    )
+    .unwrap();
+
+    let conversation_id = ConversationId::from_string(&Uuid::new_v4().to_string()).unwrap();
+    let recorder = crate::rollout::RolloutRecorder::new(
+        &config,
+        RolloutRecorderParams::new(conversation_id, None, SessionSource::Cli),
+    )
+    .await
+    .unwrap();
+    let rollout_path = recorder.rollout_path.clone();
+    let raw_image = format!("data:image/png;base64,{}", "A".repeat(8 * 1024));
+
+    recorder
+        .record_events(&[RecordedEvent {
+            id: "event-user-image".to_string(),
+            event_seq: 1,
+            order: None,
+            msg: ProtoEventMsg::UserMessage(UserMessageEvent {
+                message: "see screenshot".to_string(),
+                images: Some(vec![raw_image]),
+                local_images: vec![],
+                text_elements: vec![],
+            }),
+        }])
+        .await
+        .unwrap();
+    recorder.shutdown().await.unwrap();
+
+    let text = fs::read_to_string(rollout_path).unwrap();
+    assert!(!text.contains("data:image"));
+    assert!(text.contains("image omitted from reusable history"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add reusable history compaction for old images, image-generation payloads, and large tool outputs
- preserve the active turn's newest recorded item so fresh images still reach the model
- compact response items and replacement histories before rollout storage so new session files do not keep raw image ballast

Closes #45

## Validation
- cargo test -p code-core history_compaction --no-default-features
- ./build-fast.sh