### PR TITLE
Avoid replaying generated image payloads

### DIFF
--- a/code-rs/core/src/client_common.rs
+++ b/code-rs/core/src/client_common.rs
@@ -8,6 +8,7 @@ use crate::model_family::ModelFamily;
 use crate::openai_tools::OpenAiTool;
 use crate::protocol::RateLimitSnapshotEvent;
 use crate::protocol::TokenUsage;
+use crate::truncate::truncate_middle;
 use crate::user_instructions::UserInstructions;
 use code_protocol::models::ContentItem;
 use code_protocol::models::FunctionCallOutputContentItem;
@@ -428,6 +429,7 @@ fn limit_screenshots_in_input(input: &mut Vec<ResponseItem>) {
 
 const SPARK_IMAGE_PLACEHOLDER: &str =
     "[image omitted: selected -spark model does not support image inputs]";
+const IMAGE_GENERATION_REVISED_PROMPT_MAX_BYTES: usize = 8 * 1024;
 
 /// Replace `input_image` payloads with text placeholders for models that are
 /// known not to accept image inputs.
@@ -463,24 +465,38 @@ pub(crate) fn replace_image_payloads_for_model(input: &mut Vec<ResponseItem>, mo
     }
 }
 
-/// Convert upstream `image_generation_call` output items into standard user
-/// `input_image` messages when we replay stateless history.
+/// Replace upstream `image_generation_call` output items with bounded text when
+/// we replay stateless history.
 pub(crate) fn rewrite_image_generation_calls_for_input(input: &mut Vec<ResponseItem>) {
     let original_items = std::mem::take(input);
     *input = original_items
         .into_iter()
         .map(|item| match item {
-            ResponseItem::ImageGenerationCall { result, .. } => {
-                let image_url = if result.starts_with("data:") {
-                    result
-                } else {
-                    format!("data:image/png;base64,{result}")
-                };
+            ResponseItem::ImageGenerationCall {
+                status,
+                revised_prompt,
+                result,
+                ..
+            } => {
+                let bytes = result.len();
+                let mut text = format!(
+                    "[image generation result omitted from conversation replay; status={status}; {bytes} bytes]"
+                );
+                if let Some(revised_prompt) = revised_prompt {
+                    text.push_str("\nRevised prompt: ");
+                    text.push_str(
+                        &truncate_middle(
+                            &revised_prompt,
+                            IMAGE_GENERATION_REVISED_PROMPT_MAX_BYTES,
+                        )
+                        .0,
+                    );
+                }
 
                 ResponseItem::Message {
                     id: None,
-                    role: "user".to_string(),
-                    content: vec![ContentItem::InputImage { image_url }],
+                    role: "assistant".to_string(),
+                    content: vec![ContentItem::OutputText { text }],
                     end_turn: None,
                     phase: None,
                 }
@@ -633,11 +649,11 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_image_generation_calls_for_input_converts_to_user_image_message() {
+    fn rewrite_image_generation_calls_for_input_converts_to_bounded_assistant_message() {
         let mut input = vec![ResponseItem::ImageGenerationCall {
             id: "ig_1".to_string(),
             status: "completed".to_string(),
-            revised_prompt: None,
+            revised_prompt: Some("a tidy diagram".to_string()),
             result: "Zm9v".to_string(),
         }];
 
@@ -647,12 +663,52 @@ mod tests {
         assert!(matches!(
             &input[0],
             ResponseItem::Message { role, content, .. }
-                if role == "user"
+                if role == "assistant"
                     && matches!(
                         content.first(),
-                        Some(ContentItem::InputImage { image_url })
-                            if image_url == "data:image/png;base64,Zm9v"
+                        Some(ContentItem::OutputText { text })
+                            if text.contains("image generation result omitted")
+                                && text.contains("status=completed")
+                                && text.contains("4 bytes")
+                                && text.contains("a tidy diagram")
+                                && !text.contains("Zm9v")
                     )
+        ));
+    }
+
+    #[test]
+    fn old_image_generation_results_are_not_replayed_as_full_images() {
+        let mut input = vec![
+            ResponseItem::ImageGenerationCall {
+                id: "ig_old".to_string(),
+                status: "completed".to_string(),
+                revised_prompt: None,
+                result: "A".repeat(64 * 1024),
+            },
+            ResponseItem::Message {
+                id: None,
+                role: "user".to_string(),
+                content: vec![ContentItem::InputText {
+                    text: "continue".to_string(),
+                }],
+                end_turn: None,
+                phase: None,
+            },
+        ];
+
+        rewrite_image_generation_calls_for_input(&mut input);
+
+        assert!(matches!(
+            &input[0],
+            ResponseItem::Message { content, .. }
+                if matches!(
+                    content.first(),
+                    Some(ContentItem::OutputText { text })
+                        if text.contains("image generation result omitted")
+                            && text.contains("65536 bytes")
+                            && !text.contains("data:image")
+                            && !text.contains(&"A".repeat(1024))
+                )
         ));
     }
 

--- a/code-rs/core/tests/image_history_replay.rs
+++ b/code-rs/core/tests/image_history_replay.rs
@@ -1,0 +1,125 @@
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use common::{load_default_config_for_test, mount_sse_once, wait_for_event};
+
+use code_core::model_family::find_family_for_model;
+use code_core::protocol::{EventMsg, InputItem, Op};
+use code_core::{built_in_model_providers, CodexAuth, ConversationManager, ModelProviderInfo};
+use serde_json::Value;
+use serde_json::json;
+use tempfile::TempDir;
+use wiremock::MockServer;
+
+fn completed_sse(response_id: &str) -> String {
+    let completed = json!({
+        "type": "response.completed",
+        "response": {
+            "id": response_id,
+            "usage": {
+                "input_tokens": 0,
+                "input_tokens_details": null,
+                "output_tokens": 0,
+                "output_tokens_details": null,
+                "total_tokens": 0
+            },
+            "output": []
+        }
+    });
+    format!("event: response.completed\ndata: {completed}\n\n")
+}
+
+fn output_item_done_sse(item: Value) -> String {
+    let event = json!({
+        "type": "response.output_item.done",
+        "item": item,
+    });
+    format!("event: response.output_item.done\ndata: {event}\n\n")
+}
+
+fn request_image_payload_bytes(body: &Value) -> usize {
+    fn walk(value: &Value) -> usize {
+        match value {
+            Value::String(text) if text.starts_with("data:image/") => text.len(),
+            Value::Array(items) => items.iter().map(walk).sum(),
+            Value::Object(map) => map.values().map(walk).sum(),
+            _ => 0,
+        }
+    }
+
+    walk(&body["input"])
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn generated_images_are_not_replayed_in_next_turn_request_payload() {
+    let server = MockServer::start().await;
+    let old_image_result = "A".repeat(64 * 1024);
+
+    let first_response = format!(
+        "{}{}",
+        output_item_done_sse(json!({
+            "type": "image_generation_call",
+            "id": "ig_1",
+            "status": "completed",
+            "result": old_image_result,
+        })),
+        completed_sse("resp-image"),
+    );
+    let first_request = mount_sse_once(&server, first_response).await;
+    let second_request = mount_sse_once(&server, completed_sse("resp-next")).await;
+
+    let model_provider = ModelProviderInfo {
+        base_url: Some(format!("{}/v1", server.uri())),
+        ..built_in_model_providers(None)["openai"].clone()
+    };
+
+    let cwd = TempDir::new().unwrap();
+    let code_home = TempDir::new().unwrap();
+    let mut config = load_default_config_for_test(&code_home);
+    config.cwd = cwd.path().to_path_buf();
+    config.model_provider = model_provider;
+    config.model = "gpt-5.1-codex".to_string();
+    config.model_family = find_family_for_model(&config.model).unwrap();
+    config.include_apply_patch_tool = false;
+    config.include_view_image_tool = false;
+    config.tools_web_search_request = false;
+    config.include_plan_tool = false;
+
+    let conversation_manager =
+        ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
+    let codex = conversation_manager
+        .new_conversation(config)
+        .await
+        .expect("create new conversation")
+        .conversation;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![InputItem::Text {
+                text: "generate an image".to_string(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await
+        .unwrap();
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![InputItem::Text {
+                text: "continue".to_string(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await
+        .unwrap();
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+
+    let first_body = first_request.single_body_json();
+    let second_body = second_request.single_body_json();
+
+    assert_eq!(request_image_payload_bytes(&first_body), 0);
+    assert_eq!(request_image_payload_bytes(&second_body), 0);
+    assert!(second_body["input"].to_string().contains("image generation result omitted"));
+}


### PR DESCRIPTION
## Summary
- stop converting prior `image_generation_call` outputs back into full `data:image/...` user images during stateless replay
- replace generated image payloads with a bounded assistant text placeholder that preserves status, byte count, and a capped revised prompt
- add a two-turn integration test proving the second request no longer resends generated image payload bytes

## Why
Generated images were being recorded in history and replayed as full input images on later turns, which could burn rate limit and request budget repeatedly. This keeps useful context without resending the raw image data.

## Tracking
Refs #68
Refs #63

## Validation
- [x] `cargo test -p code-core image_generation -- --nocapture`
- [x] `cargo test -p code-core --test image_history_replay generated_images_are_not_replayed_in_next_turn_request_payload -- --nocapture`
- [x] `./build-fast.sh`

