### PR TITLE
Add JetBrains workflow metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -57,9 +57,12 @@
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
-  "relatedRepos": [
-    "code-everywhere"
-  ],
+  "relatedRepos": ["code-everywhere"],
+  "jetbrains": {
+    "ide": "IntelliJ IDEA",
+    "openProjectPath": ".",
+    "scopePreference": "changed_files"
+  },
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,


### PR DESCRIPTION
## Summary
- record JetBrains IDE/project metadata in `.github/github.json`
- prefer changed-files inspection scope for local readiness workflows

## Validation
- jq empty .github/github.json
- npx prettier --write .github/github.json
- ./build-fast.sh
