### PR TITLE
Move JetBrains metadata to workflow config

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -58,6 +58,11 @@
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": ["code-everywhere"],
+  "jetbrains": {
+    "ide": "IntelliJ IDEA",
+    "openProjectPath": ".",
+    "scopePreference": "changed_files"
+  },
   "validatedThrough": [],
   "githubSignals": {
     "postMerge": {

--- a/.github/github.json
+++ b/.github/github.json
@@ -58,11 +58,6 @@
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": ["code-everywhere"],
-  "jetbrains": {
-    "ide": "IntelliJ IDEA",
-    "openProjectPath": ".",
-    "scopePreference": "changed_files"
-  },
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,


### PR DESCRIPTION
## Summary
- move JetBrains metadata into canonical `.github/github-repo-workflow.json`
- remove the inert copy from `.github/github.json`

## Validation
- JSON parse/prettier validation hook passed during patch
- ./build-fast.sh
