### PR TITLE
Align GitHub metadata with code scanning

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -47,6 +47,9 @@
     "Release",
     "Upstream Merge",
     "binary-release",
+    "CodeQL",
+    "Dependabot Updates",
+    "Dependency Graph",
     "rust-release-argument-comment-lint",
     "rusty-v8-release",
     "v8-canary",
@@ -69,7 +72,7 @@
       "checkSecurityAndQuality": true
     },
     "capabilities": {
-      "codeScanning": "not_enabled",
+      "codeScanning": "available",
       "secretScanning": "not_enabled",
       "dependabotAlerts": "not_enabled",
       "securityAdvisories": "available"


### PR DESCRIPTION
## Summary
- mark GitHub code scanning as available in `.github/github.json`
- add active GitHub signal workflows to `importantWorkflows`: CodeQL, Dependabot Updates, Dependency Graph
- keep Dependabot alerts marked `not_enabled`, matching the current API response

Refs #40

## Validation
- `jq empty .github/github.json`
- `gh workflow list --all`
- `gh api 'repos/cbusillo/code/code-scanning/alerts?state=open' --paginate --jq 'length'` returned `15`
- `gh api 'repos/cbusillo/code/dependabot/alerts?state=open' --paginate --jq 'length'` returned HTTP 403 because Dependabot alerts are disabled
- `./build-fast.sh`
