### PR TITLE
Improve prompt context token efficiency

### DIFF
--- a/code-rs/core/src/codex.rs
+++ b/code-rs/core/src/codex.rs
@@ -1017,7 +1017,6 @@ use crate::dry_run_guard::{analyze_command, DryRunAnalysis, DryRunDisposition, D
 use crate::parse_command::parse_command;
 use crate::plan_tool::handle_update_plan;
 use crate::project_doc::get_user_instructions;
-use crate::skills::loader::load_skills;
 use crate::project_features::{ProjectCommand, ProjectHook, ProjectHooks};
 use crate::protocol::AgentMessageDeltaEvent;
 use crate::protocol::AgentMessageEvent;
@@ -1060,6 +1059,7 @@ use crate::protocol::SandboxPolicy;
 use crate::protocol::SessionConfiguredEvent;
 use crate::protocol::Submission;
 use crate::protocol::TaskCompleteEvent;
+use crate::skills::loader::load_skills;
 use std::sync::OnceLock;
 use tokio::sync::Notify;
 use crate::protocol::TurnDiffEvent;
@@ -1118,19 +1118,6 @@ impl Codex {
         let (tx_sub, rx_sub) = async_channel::unbounded();
         let (tx_event, rx_event) = async_channel::unbounded();
 
-        let skills_outcome = config.skills_enabled.then(|| load_skills(&config));
-        if let Some(outcome) = &skills_outcome {
-            for err in &outcome.errors {
-                warn!("invalid skill {}: {}", err.path.display(), err.message);
-            }
-        }
-
-        let user_instructions = get_user_instructions(
-            &config,
-            skills_outcome.as_ref().map(|outcome| outcome.skills.as_slice()),
-        )
-        .await;
-
         let configure_session = Op::ConfigureSession {
             provider: config.model_provider.clone(),
             model: config.model.clone(),
@@ -1143,7 +1130,7 @@ impl Codex {
             context_mode: config.context_mode,
             model_context_window: config.model_context_window,
             model_auto_compact_token_limit: config.model_auto_compact_token_limit,
-            user_instructions,
+            user_instructions: config.user_instructions.clone(),
             base_instructions: config.base_instructions.clone(),
             approval_policy: config.approval_policy,
             sandbox_policy: config.sandbox_policy.clone(),

--- a/code-rs/core/src/codex.rs
+++ b/code-rs/core/src/codex.rs
@@ -363,6 +363,57 @@ fn response_input_from_core_items(items: Vec<InputItem>) -> ResponseInputItem {
     }
 }
 
+fn selected_skill_messages_from_input(
+    items: &[InputItem],
+    skills: &[crate::skills::SkillMetadata],
+) -> Vec<ResponseItem> {
+    let requested = selected_skill_names_from_input(items);
+    if requested.is_empty() {
+        return Vec::new();
+    }
+
+    let mut messages = Vec::new();
+    for skill in skills {
+        if requested
+            .iter()
+            .any(|requested_name| requested_name.eq_ignore_ascii_case(&skill.name))
+        {
+            messages.push(
+                SkillInstructions {
+                    name: skill.name.clone(),
+                    path: skill.path.to_string_lossy().replace('\\', "/"),
+                    contents: skill.content.clone(),
+                }
+                .into(),
+            );
+        }
+    }
+    messages
+}
+
+fn selected_skill_names_from_input(items: &[InputItem]) -> Vec<String> {
+    let mut names = Vec::new();
+    for item in items {
+        let InputItem::Text { text } = item else {
+            continue;
+        };
+        for token in text.split_whitespace() {
+            let Some(name) = token.strip_prefix('$') else {
+                continue;
+            };
+            let name = name
+                .trim_matches(|ch: char| {
+                    !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+                })
+                .to_string();
+            if !name.is_empty() && !names.iter().any(|existing| existing == &name) {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
 fn convert_call_tool_result_to_function_call_output_payload(
     result: &Result<CallToolResult, String>,
 ) -> FunctionCallOutputPayload {
@@ -855,6 +906,9 @@ fn should_include_browser_screenshot(
 mod tests {
     use super::*;
     use crate::codex::streaming::{process_rollout_env_item, TimelineReplayContext};
+    use crate::skills::SkillMetadata;
+    use crate::skills::model::SkillPolicy;
+    use crate::skills::model::SkillScope;
     use code_protocol::models::ContentItem;
     use pretty_assertions::assert_eq;
 
@@ -868,6 +922,36 @@ mod tests {
         assert!(should_include_browser_screenshot(&mut last, &path, Some(hash_one.clone())));
         assert!(!should_include_browser_screenshot(&mut last, &path, Some(hash_one.clone())));
         assert!(should_include_browser_screenshot(&mut last, &path, Some(hash_two)));
+    }
+
+    #[test]
+    fn selected_skill_messages_include_explicit_dollar_skill_once() {
+        let skills = vec![SkillMetadata {
+            name: "manual-skill".to_string(),
+            description: "Manual skill".to_string(),
+            path: PathBuf::from("/tmp/manual-skill/SKILL.md"),
+            scope: SkillScope::User,
+            content: "manual body".to_string(),
+            policy: Some(SkillPolicy {
+                allow_implicit_invocation: Some(false),
+            }),
+        }];
+        let input = vec![InputItem::Text {
+            text: "Please use $manual-skill for this turn, then reply.".to_string(),
+        }];
+
+        let messages = selected_skill_messages_from_input(&input, &skills);
+
+        assert_eq!(messages.len(), 1);
+        let ResponseItem::Message { role, content, .. } = &messages[0] else {
+            panic!("expected skill message");
+        };
+        assert_eq!(role, "user");
+        let [ContentItem::InputText { text }] = content.as_slice() else {
+            panic!("expected skill text");
+        };
+        assert!(text.contains("<name>manual-skill</name>"));
+        assert!(text.contains("manual body"));
     }
 
     fn make_snapshot(cwd: &str) -> EnvironmentContextSnapshot {
@@ -977,7 +1061,9 @@ use crate::environment_context::{
     EnvironmentContextTracker,
     ViewportDimensions,
 };
+use crate::user_instructions::SkillInstructions;
 use crate::user_instructions::UserInstructions;
+use crate::user_instructions::is_skill_instructions_message;
 use crate::config::{persist_model_selection, Config};
 use crate::timeboxed_exec_guidance::{
     AUTO_EXEC_TIMEBOXED_CLI_GUIDANCE,

--- a/code-rs/core/src/codex/session.rs
+++ b/code-rs/core/src/codex/session.rs
@@ -466,6 +466,7 @@ pub(crate) struct Session {
     pub(super) disable_response_storage: bool,
     pub(super) tools_config: ToolsConfig,
     pub(super) dynamic_tools: Vec<DynamicToolSpec>,
+    pub(super) skills: Vec<crate::skills::SkillMetadata>,
 
     /// Manager for external MCP servers/tools.
     pub(super) mcp_connection_manager: McpConnectionManager,

--- a/code-rs/core/src/codex/streaming.rs
+++ b/code-rs/core/src/codex/streaming.rs
@@ -780,6 +780,10 @@ pub(super) async fn submission_loop(
                     remote_models_manager,
                     tools_config,
                     dynamic_tools,
+                    skills: skills_outcome
+                        .as_ref()
+                        .map(|outcome| outcome.skills.clone())
+                        .unwrap_or_default(),
                     tx_event: tx_event.clone(),
                     user_instructions: effective_user_instructions.clone(),
                     base_instructions,
@@ -2443,21 +2447,26 @@ async fn run_agent(
     }
 
     let mut initial_response_item: Option<ResponseItem> = None;
+    let mut initial_skill_messages: Vec<ResponseItem> = Vec::new();
 
     if !pending_only_turn {
         // Convert input to ResponseInputItem
         let mut response_input = response_input_from_core_items(input.clone());
         sess.enforce_user_message_limits(&sub_id, &mut response_input);
         let response_item: ResponseItem = response_input.into();
+        let selected_skill_messages =
+            selected_skill_messages_from_input(&input, &sess.skills);
 
         if is_review_mode {
             review_history.push(response_item.clone());
+            review_history.extend(selected_skill_messages.clone());
         } else {
             // Record to history but we'll handle ephemeral images separately
             sess.record_conversation_items(&[response_item.clone()])
                 .await;
         }
         initial_response_item = Some(response_item);
+        initial_skill_messages = selected_skill_messages;
     }
 
     let mut last_task_message: Option<String> = None;
@@ -2584,13 +2593,21 @@ async fn run_agent(
             let existing_history = sess.state.lock().unwrap().history.contents();
             let pending_input_tail =
                 pending_items_not_already_recorded(&pending_input_tail, &existing_history);
-            sess.turn_input_with_history(pending_input_tail)
+            let mut turn_input = sess.turn_input_with_history(pending_input_tail);
+            if !initial_skill_messages.is_empty() {
+                turn_input.extend(initial_skill_messages.clone());
+            }
+            turn_input
         };
 
         let turn_input_messages: Vec<String> = turn_input
             .iter()
             .filter_map(|item| match item {
-                ResponseItem::Message { role, content, .. } if role == "user" => Some(content),
+                ResponseItem::Message { role, content, .. }
+                    if role == "user" && !is_skill_instructions_message(content) =>
+                {
+                    Some(content)
+                }
                 _ => None,
             })
             .flat_map(|content| {
@@ -2606,6 +2623,7 @@ async fn run_agent(
             &mut turn_diff_tracker,
             sub_id.clone(),
             initial_response_item.clone(),
+            initial_skill_messages.clone(),
             pending_input_tail,
             turn_input,
         )
@@ -2947,6 +2965,7 @@ async fn run_turn(
     turn_diff_tracker: &mut TurnDiffTracker,
     sub_id: String,
     initial_user_item: Option<ResponseItem>,
+    initial_skill_messages: Vec<ResponseItem>,
     pending_input_tail: Vec<ResponseItem>,
     mut input: Vec<ResponseItem>,
 ) -> CodexResult<Vec<ProcessedResponseItem>> {
@@ -3341,6 +3360,7 @@ async fn run_turn(
                             if let Some(initial_item) = initial_user_item.clone() {
                                 rebuilt.push(initial_item);
                             }
+                            rebuilt.extend(initial_skill_messages.clone());
                             if !pending_input_tail.is_empty() {
                                 let (missing_calls, filtered_outputs) =
                                     reconcile_pending_tool_outputs(&pending_input_tail, &rebuilt, &previous_input_snapshot);

--- a/code-rs/core/src/codex/streaming.rs
+++ b/code-rs/core/src/codex/streaming.rs
@@ -2523,7 +2523,12 @@ async fn run_agent(
             first_iteration = false;
         } else {
             // Only record pending input to history on subsequent iterations
-            sess.record_conversation_items(&pending_input).await;
+            let existing_history = sess.state.lock().unwrap().history.contents();
+            let pending_input_to_record =
+                pending_items_not_already_recorded(&pending_input, &existing_history);
+            if !pending_input_to_record.is_empty() {
+                sess.record_conversation_items(&pending_input_to_record).await;
+            }
         }
 
         if auto_compact_pending && !is_review_mode {
@@ -2576,7 +2581,10 @@ async fn run_agent(
             }
             review_history.clone()
         } else {
-            sess.turn_input_with_history(pending_input_tail.clone())
+            let existing_history = sess.state.lock().unwrap().history.contents();
+            let pending_input_tail =
+                pending_items_not_already_recorded(&pending_input_tail, &existing_history);
+            sess.turn_input_with_history(pending_input_tail)
         };
 
         let turn_input_messages: Vec<String> = turn_input
@@ -3889,6 +3897,32 @@ fn collect_tool_call_ids(items: &[ResponseItem]) -> HashSet<String> {
         }
     }
     ids
+}
+
+fn pending_items_not_already_recorded(
+    pending_items: &[ResponseItem],
+    recorded_items: &[ResponseItem],
+) -> Vec<ResponseItem> {
+    if recorded_items.is_empty() {
+        return pending_items.to_vec();
+    }
+
+    pending_items
+        .iter()
+        .filter(|pending| {
+            !is_tool_output_item(pending) || !recorded_items.iter().any(|recorded| recorded == *pending)
+        })
+        .cloned()
+        .collect()
+}
+
+fn is_tool_output_item(item: &ResponseItem) -> bool {
+    matches!(
+        item,
+        ResponseItem::FunctionCallOutput { .. }
+            | ResponseItem::CustomToolCallOutput { .. }
+            | ResponseItem::ToolSearchOutput { .. }
+    )
 }
 
 fn find_call_item_by_id(items: &[ResponseItem], call_id: &str) -> Option<ResponseItem> {
@@ -14193,6 +14227,7 @@ mod tests {
         save_image_generation_result,
         save_image_generation_sidecar,
         ImageGenerationTurnMetadata,
+        pending_items_not_already_recorded,
         spark_fallback_model,
         TRUNCATION_MARKER,
     };
@@ -14342,6 +14377,30 @@ mod tests {
 
         assert_eq!(text, "[image: hero]");
         assert!(!text.contains("base64"));
+    }
+
+    #[test]
+    fn pending_items_omit_tool_outputs_already_recorded() {
+        let output = FunctionCallOutputPayload::from_text("done".to_string());
+        let pending_output = code_protocol::models::ResponseItem::FunctionCallOutput {
+            call_id: "call-1".to_string(),
+            output: output.clone(),
+        };
+        let pending_message = code_protocol::models::ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![code_protocol::models::ContentItem::InputText {
+                text: "repeatable".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        };
+        let pending = vec![pending_output.clone(), pending_message.clone()];
+        let recorded = vec![pending_output];
+
+        let filtered = pending_items_not_already_recorded(&pending, &recorded);
+
+        assert_eq!(filtered, vec![pending_message]);
     }
 
     #[test]

--- a/code-rs/core/src/project_doc.rs
+++ b/code-rs/core/src/project_doc.rs
@@ -464,6 +464,7 @@ mod tests {
             path: skill_path,
             scope: SkillScope::User,
             content: String::new(),
+            policy: None,
         }];
 
         let rendered = get_user_instructions(&make_config(&tmp, 4096, Some("base")), Some(&skills))

--- a/code-rs/core/src/project_doc.rs
+++ b/code-rs/core/src/project_doc.rs
@@ -38,6 +38,7 @@ pub(crate) async fn get_user_instructions(
     skills: Option<&[SkillMetadata]>,
 ) -> Option<String> {
     let skills_section = skills.and_then(render_skills_section);
+    let skills_section_key = skills_section.as_ref().map(|section| section.trim().to_string());
 
     let project_doc_parts = match read_project_doc_parts(config).await {
         Ok(Some(parts)) => parts,
@@ -49,6 +50,11 @@ pub(crate) async fn get_user_instructions(
     };
 
     let mut seen: HashSet<String> = HashSet::new();
+    let rendered_project_doc_parts = config
+        .user_instructions
+        .as_deref()
+        .and_then(rendered_project_doc_parts)
+        .map(str::to_string);
 
     let mut base_instructions: Option<String> = None;
     if let Some(original) = &config.user_instructions {
@@ -56,6 +62,11 @@ pub(crate) async fn get_user_instructions(
         if !key.is_empty() && seen.insert(key.to_string()) {
             base_instructions = Some(original.clone());
         }
+        mark_rendered_skills_section_seen(
+            rendered_project_doc_parts.as_deref(),
+            skills_section_key.as_deref(),
+            &mut seen,
+        );
     }
 
     let mut unique_project_docs: Vec<String> = Vec::new();
@@ -63,6 +74,13 @@ pub(crate) async fn get_user_instructions(
         let key = doc.trim();
         if key.is_empty() {
             continue;
+        }
+
+        if rendered_project_doc_parts
+            .as_deref()
+            .is_some_and(|rendered| rendered.contains(key))
+        {
+            seen.insert(key.to_string());
         }
 
         if seen.insert(key.to_string()) {
@@ -84,6 +102,27 @@ pub(crate) async fn get_user_instructions(
         (Some(base), false) => {
             let docs = unique_project_docs.join("\n\n");
             Some(format!("{base}{PROJECT_DOC_SEPARATOR}{docs}"))
+        }
+    }
+}
+
+fn rendered_project_doc_parts(rendered: &str) -> Option<&str> {
+    rendered.split_once(PROJECT_DOC_SEPARATOR).map(|(_, docs)| docs)
+}
+
+fn mark_rendered_skills_section_seen(
+    rendered_project_doc_parts: Option<&str>,
+    skills_section_key: Option<&str>,
+    seen: &mut HashSet<String>,
+) {
+    if let (Some(rendered_project_doc_parts), Some(skills_section_key)) =
+        (rendered_project_doc_parts, skills_section_key)
+    {
+        if rendered_project_doc_parts
+            .trim_end()
+            .ends_with(skills_section_key)
+        {
+            seen.insert(skills_section_key.to_string());
         }
     }
 }
@@ -269,6 +308,8 @@ mod tests {
     use super::*;
     use crate::config::ConfigOverrides;
     use crate::config::ConfigToml;
+    use crate::skills::SkillMetadata;
+    use crate::skills::model::SkillScope;
     use std::fs;
     use tempfile::TempDir;
 
@@ -410,6 +451,31 @@ mod tests {
             .expect("instructions expected");
 
         assert_eq!(res, "same text");
+    }
+
+    #[tokio::test]
+    async fn does_not_recompose_rendered_project_docs_and_skills() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("AGENTS.md"), "project guidance").unwrap();
+        let skill_path = tmp.path().join("skills").join("demo").join("SKILL.md");
+        let skills = vec![SkillMetadata {
+            name: "demo".to_string(),
+            description: "Demo skill".to_string(),
+            path: skill_path,
+            scope: SkillScope::User,
+            content: String::new(),
+        }];
+
+        let rendered = get_user_instructions(&make_config(&tmp, 4096, Some("base")), Some(&skills))
+            .await
+            .expect("instructions expected");
+        let recomposed = get_user_instructions(&make_config(&tmp, 4096, Some(&rendered)), Some(&skills))
+            .await
+            .expect("instructions expected");
+
+        assert_eq!(recomposed, rendered);
+        assert_eq!(recomposed.matches(PROJECT_DOC_SEPARATOR).count(), 1);
+        assert_eq!(recomposed.matches("### Available skills").count(), 1);
     }
 
     /// If the base instructions match the root doc but there is additional

--- a/code-rs/core/src/skills/loader.rs
+++ b/code-rs/core/src/skills/loader.rs
@@ -4,6 +4,7 @@ use crate::git_info::resolve_root_git_project_for_trust;
 use crate::skills::model::SkillError;
 use crate::skills::model::SkillLoadOutcome;
 use crate::skills::model::SkillMetadata;
+use crate::skills::model::SkillPolicy;
 use crate::skills::model::SkillScope;
 use crate::skills::system::system_cache_root_dir;
 use crate::skills::system::install_system_skills;
@@ -22,6 +23,14 @@ use tracing::error;
 struct SkillFrontmatter {
     name: String,
     description: String,
+    #[serde(default)]
+    policy: Option<SkillFrontmatterPolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillFrontmatterPolicy {
+    #[serde(default)]
+    allow_implicit_invocation: Option<bool>,
 }
 
 const SKILLS_FILENAME: &str = "SKILL.md";
@@ -320,6 +329,9 @@ fn parse_skill_file(path: &Path, scope: SkillScope) -> Result<SkillMetadata, Ski
         path: resolved_path,
         scope,
         content: contents,
+        policy: parsed.policy.map(|policy| SkillPolicy {
+            allow_implicit_invocation: policy.allow_implicit_invocation,
+        }),
     })
 }
 
@@ -444,8 +456,59 @@ mod tests {
         skill_path
     }
 
+    fn write_manual_skill_at(
+        skills_root: &Path,
+        dir: &str,
+        name: &str,
+        description: &str,
+    ) -> PathBuf {
+        let skill_dir = skills_root.join(dir);
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
+        let skill_path = skill_dir.join(SKILLS_FILENAME);
+        fs::write(
+            &skill_path,
+            format!(
+                "---\nname: {name}\ndescription: {description}\npolicy:\n  allow_implicit_invocation: false\n---\n\n# {name}\n"
+            ),
+        )
+        .expect("write skill file");
+        skill_path
+    }
+
     fn normalized(path: &Path) -> PathBuf {
         normalize_path(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    #[test]
+    fn loads_skill_policy_from_frontmatter() {
+        let skills_root = tempfile::tempdir().expect("tempdir");
+        let skill_path = write_manual_skill_at(
+            skills_root.path(),
+            "manual",
+            "manual-skill",
+            "Manual skill",
+        );
+
+        let outcome = load_skills_from_roots(vec![SkillRoot {
+            path: skills_root.path().to_path_buf(),
+            scope: SkillScope::User,
+        }]);
+
+        assert!(
+            outcome.errors.is_empty(),
+            "unexpected errors: {:?}",
+            outcome.errors
+        );
+        assert_eq!(outcome.skills.len(), 1);
+        let skill = &outcome.skills[0];
+        assert_eq!(skill.path, normalized(&skill_path));
+        assert_eq!(
+            skill.policy,
+            Some(SkillPolicy {
+                allow_implicit_invocation: Some(false),
+            })
+        );
+        assert!(!skill.allow_implicit_invocation());
     }
 
     #[test]

--- a/code-rs/core/src/skills/model.rs
+++ b/code-rs/core/src/skills/model.rs
@@ -15,6 +15,21 @@ pub struct SkillMetadata {
     pub path: PathBuf,
     pub scope: SkillScope,
     pub content: String,
+    pub policy: Option<SkillPolicy>,
+}
+
+impl SkillMetadata {
+    pub fn allow_implicit_invocation(&self) -> bool {
+        self.policy
+            .as_ref()
+            .and_then(|policy| policy.allow_implicit_invocation)
+            .unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SkillPolicy {
+    pub allow_implicit_invocation: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code-rs/core/src/skills/render.rs
+++ b/code-rs/core/src/skills/render.rs
@@ -1,6 +1,11 @@
 use crate::skills::model::SkillMetadata;
 
 pub fn render_skills_section(skills: &[SkillMetadata]) -> Option<String> {
+    let skills: Vec<&SkillMetadata> = skills
+        .iter()
+        .filter(|skill| skill.allow_implicit_invocation())
+        .collect();
+
     if skills.is_empty() {
         return None;
     }
@@ -39,4 +44,44 @@ pub fn render_skills_section(skills: &[SkillMetadata]) -> Option<String> {
     );
 
     Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::model::SkillPolicy;
+    use crate::skills::model::SkillScope;
+    use std::path::PathBuf;
+
+    fn skill(name: &str, allow_implicit_invocation: Option<bool>) -> SkillMetadata {
+        SkillMetadata {
+            name: name.to_string(),
+            description: format!("{name} description"),
+            path: PathBuf::from(format!("/tmp/{name}/SKILL.md")),
+            scope: SkillScope::User,
+            content: String::new(),
+            policy: allow_implicit_invocation.map(|allow_implicit_invocation| SkillPolicy {
+                allow_implicit_invocation: Some(allow_implicit_invocation),
+            }),
+        }
+    }
+
+    #[test]
+    fn render_skills_section_omits_manual_only_skills() {
+        let rendered = render_skills_section(&[
+            skill("implicit", None),
+            skill("manual", Some(false)),
+        ])
+        .expect("implicit skill should render");
+
+        assert!(rendered.contains("- implicit: implicit description"));
+        assert!(!rendered.contains("- manual: manual description"));
+    }
+
+    #[test]
+    fn render_skills_section_returns_none_for_only_manual_skills() {
+        let rendered = render_skills_section(&[skill("manual", Some(false))]);
+
+        assert!(rendered.is_none());
+    }
 }

--- a/code-rs/core/src/user_instructions.rs
+++ b/code-rs/core/src/user_instructions.rs
@@ -64,6 +64,14 @@ impl From<SkillInstructions> for ResponseItem {
     }
 }
 
+pub(crate) fn is_skill_instructions_message(message: &[ContentItem]) -> bool {
+    if let [ContentItem::InputText { text }] = message {
+        text.starts_with("<skill>\n")
+    } else {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/code-rs/core/tests/prompt_context_dedup.rs
+++ b/code-rs/core/tests/prompt_context_dedup.rs
@@ -1,0 +1,114 @@
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use common::{load_default_config_for_test, mount_sse_once, wait_for_event};
+
+use code_core::model_family::find_family_for_model;
+use code_core::protocol::{EventMsg, InputItem, Op};
+use code_core::{built_in_model_providers, CodexAuth, ConversationManager, ModelProviderInfo};
+use serde_json::Value;
+use serde_json::json;
+use tempfile::TempDir;
+use wiremock::MockServer;
+
+fn completed_sse(response_id: &str) -> String {
+    let completed = json!({
+        "type": "response.completed",
+        "response": {
+            "id": response_id,
+            "usage": {
+                "input_tokens": 0,
+                "input_tokens_details": null,
+                "output_tokens": 0,
+                "output_tokens_details": null,
+                "total_tokens": 0
+            },
+            "output": []
+        }
+    });
+    format!("event: response.completed\ndata: {completed}\n\n")
+}
+
+fn request_text(body: &Value) -> String {
+    fn walk(value: &Value, output: &mut Vec<String>) {
+        match value {
+            Value::String(text) => output.push(text.clone()),
+            Value::Array(items) => {
+                for item in items {
+                    walk(item, output);
+                }
+            }
+            Value::Object(map) => {
+                for value in map.values() {
+                    walk(value, output);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut output = Vec::new();
+    walk(&body["input"], &mut output);
+    output.join("\n")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initial_session_request_does_not_duplicate_project_docs_or_skills() {
+    let server = MockServer::start().await;
+    let request = mount_sse_once(&server, completed_sse("resp-dedup")).await;
+
+    let model_provider = ModelProviderInfo {
+        base_url: Some(format!("{}/v1", server.uri())),
+        ..built_in_model_providers(None)["openai"].clone()
+    };
+
+    let cwd = TempDir::new().unwrap();
+    std::fs::write(cwd.path().join("AGENTS.md"), "project guidance").unwrap();
+    let skill_dir = cwd.path().join(".codex").join("skills").join("demo");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Demo skill\n---\nUse the demo skill.\n",
+    )
+    .unwrap();
+
+    let code_home = TempDir::new().unwrap();
+    let mut config = load_default_config_for_test(&code_home);
+    config.cwd = cwd.path().to_path_buf();
+    config.model_provider = model_provider;
+    config.model = "gpt-5.1-codex".to_string();
+    config.model_family = find_family_for_model(&config.model).unwrap();
+    config.user_instructions = Some("base guidance".to_string());
+    config.include_apply_patch_tool = false;
+    config.include_view_image_tool = false;
+    config.tools_web_search_request = false;
+    config.include_plan_tool = false;
+
+    let conversation_manager =
+        ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
+    let codex = conversation_manager
+        .new_conversation(config)
+        .await
+        .expect("create new conversation")
+        .conversation;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![InputItem::Text {
+                text: "hello".to_string(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await
+        .unwrap();
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+
+    let body = request.single_body_json();
+    let text = request_text(&body);
+
+    assert_eq!(text.matches("--- project-doc ---").count(), 1);
+    assert_eq!(text.matches("project guidance").count(), 1);
+    assert_eq!(text.matches("### Available skills").count(), 1);
+    assert_eq!(text.matches("- demo: Demo skill").count(), 1);
+}

--- a/tools/code-exec-harness/AGENTS.md
+++ b/tools/code-exec-harness/AGENTS.md
@@ -1,0 +1,40 @@
+# Code Exec Harness Agent Guidance
+
+Use this harness as the default proving ground for realistic `code exec`
+behavior when working on token efficiency, prompt/context composition, skills,
+memory, compaction, resume, model routing, tool choice, and GitHub automation.
+
+The goal is effectiveness-adjusted token efficiency: reduce wasted tokens only
+when task success, reliability, instruction following, and useful tool behavior
+are preserved or improved. Saving tokens by making the agent less capable is a
+regression.
+
+Validation order:
+
+1. Prefer deterministic fake `/v1/responses` scenarios when request bodies,
+   JSONL events, fake service state, or tool calls can prove the behavior.
+2. Use live model runs when the question depends on model behavior that a fake
+   response cannot represent.
+3. Use local model runs when available and adequate for the scenario,
+   especially for repeated exploratory checks.
+4. Keep lower-level Rust tests for local mechanics, but add a harness scenario
+   when the risk crosses config loading, skills, memory, resume, prompt
+   assembly, tool routing, or full `code exec` behavior.
+
+When adding or running scenarios, preserve evidence future agents can compare:
+
+- request shape and duplicated context markers
+- token usage when available
+- tool commands and fake service calls
+- final answer quality or task completion signal
+- resume and compaction behavior across turns
+- unexpected retries, confusion, or wasted work
+
+For context-bloat regressions, prefer exact-count assertions over broad
+contains/not_contains checks. A project doc, skill manifest, memory block,
+summary, or large artifact placeholder should appear the intended number of
+times, usually once.
+
+Spending real OpenAI tokens in this harness is acceptable when it answers an
+effectiveness question. Try fake responses first, but do not optimize away the
+evidence needed to avoid larger token waste in real sessions.

--- a/tools/code-exec-harness/AGENTS.md
+++ b/tools/code-exec-harness/AGENTS.md
@@ -35,6 +35,15 @@ contains/not_contains checks. A project doc, skill manifest, memory block,
 summary, or large artifact placeholder should appear the intended number of
 times, usually once.
 
+Assert the request shape that the real executable sends, not the shape of a
+lower-level helper. For example, `code exec` renders project guidance as an
+`AGENTS.md instructions for ...` user-context message, while lower-level core
+helpers may use internal separators such as `--- project-doc ---`.
+
+When a harness scenario exposes a stale or ambiguous config surface, document it
+as a separate issue or issue comment instead of forcing a scenario to pass by
+asserting the wrong behavior. Keep each scenario focused on one product claim.
+
 Spending real OpenAI tokens in this harness is acceptable when it answers an
 effectiveness question. Try fake responses first, but do not optimize away the
 evidence needed to avoid larger token waste in real sessions.

--- a/tools/code-exec-harness/README.md
+++ b/tools/code-exec-harness/README.md
@@ -7,6 +7,12 @@ Use it to compare Every Code behavior across prompt, memory, skill, model, and
 configuration variants without writing to real GitHub or reusing the real
 `CODE_HOME`.
 
+Agent-specific testing policy lives in `AGENTS.md` in this directory. In short,
+use this harness as the proving ground for effectiveness-adjusted token
+efficiency work: prefer fake `/v1/responses` assertions first, use live tokens
+when model behavior is the question, and preserve evidence that future runs can
+compare.
+
 The harness defaults `code exec` to `danger-full-access` because external tool
 shims such as fake `gh` need to write logs and state outside the fixture
 workspace. Run it only with trusted scenarios.

--- a/tools/code-exec-harness/harness.py
+++ b/tools/code-exec-harness/harness.py
@@ -770,6 +770,8 @@ def request_assertion_target(request: dict[str, Any], assertion: dict[str, Any])
         return body
     if scope == "input":
         return body.get("input") if isinstance(body, dict) else None
+    if scope == "instructions":
+        return body.get("instructions") if isinstance(body, dict) else None
     raise HarnessError(f"unsupported responses assertion scope: {scope}")
 
 

--- a/tools/code-exec-harness/harness.py
+++ b/tools/code-exec-harness/harness.py
@@ -148,6 +148,16 @@ def contains_text(value: Any, needle: str) -> bool:
     return False
 
 
+def count_text(value: Any, needle: str) -> int:
+    if isinstance(value, str):
+        return value.count(needle)
+    if isinstance(value, list):
+        return sum(count_text(item, needle) for item in value)
+    if isinstance(value, dict):
+        return sum(count_text(item, needle) for item in value.values())
+    return 0
+
+
 def expand_fixture_value(value: Any) -> Any:
     if isinstance(value, dict):
         if set(value.keys()) == {"$repeat", "count"}:
@@ -818,6 +828,14 @@ def assert_expectations(summary: dict[str, Any], scenario: dict[str, Any]) -> li
             failures.append(
                 f"responses request {assertion.get('request', 0)} unexpectedly contained {assertion['not_contains']!r}"
             )
+        counts = assertion.get("count")
+        if isinstance(counts, dict):
+            for needle, expected in counts.items():
+                actual = count_text(target, str(needle))
+                if actual != int(expected):
+                    failures.append(
+                        f"responses request {assertion.get('request', 0)} count for {needle!r} expected {expected}, got {actual}"
+                    )
     return failures
 
 

--- a/tools/code-exec-harness/scenarios/manual-skill-explicit-invocation.json
+++ b/tools/code-exec-harness/scenarios/manual-skill-explicit-invocation.json
@@ -1,0 +1,36 @@
+{
+  "name": "manual-skill-explicit-invocation",
+  "model": "gpt-5.1-codex",
+  "prompt": "Use $manual-skill and reply with exactly: ok",
+  "files": {
+    ".codex/skills/implicit/SKILL.md": "---\nname: implicit-skill\ndescription: Implicit skill\n---\nUse the implicit skill.\n",
+    ".codex/skills/manual/SKILL.md": "---\nname: manual-skill\ndescription: Manual skill\npolicy:\n  allow_implicit_invocation: false\n---\nMANUAL_SKILL_BODY_MARKER\n",
+    "README.md": "# Manual skill invocation fixture\n"
+  },
+  "responses_api": {
+    "responses": [
+      {
+        "response_id": "resp-manual-skill-explicit"
+      }
+    ]
+  },
+  "expect": {
+    "returncode": 0,
+    "responses_request_count": 1,
+    "responses": [
+      {
+        "request": 0,
+        "scope": "input",
+        "count": {
+          "### Available skills": 1,
+          "- implicit-skill: Implicit skill": 1,
+          "- manual-skill: Manual skill": 0,
+          "<name>manual-skill</name>": 1,
+          "MANUAL_SKILL_BODY_MARKER": 1
+        }
+      }
+    ]
+  },
+  "max_seconds": 30,
+  "timeout_seconds": 90
+}

--- a/tools/code-exec-harness/scenarios/manual-skill-not-implicit.json
+++ b/tools/code-exec-harness/scenarios/manual-skill-not-implicit.json
@@ -1,0 +1,34 @@
+{
+  "name": "manual-skill-not-implicit",
+  "model": "gpt-5.1-codex",
+  "prompt": "Reply with exactly: ok",
+  "files": {
+    ".codex/skills/implicit/SKILL.md": "---\nname: implicit-skill\ndescription: Implicit skill\n---\nUse the implicit skill.\n",
+    ".codex/skills/manual/SKILL.md": "---\nname: manual-skill\ndescription: Manual skill\npolicy:\n  allow_implicit_invocation: false\n---\nUse the manual skill only when explicitly requested.\n",
+    "README.md": "# Manual skill fixture\n"
+  },
+  "responses_api": {
+    "responses": [
+      {
+        "response_id": "resp-manual-skill"
+      }
+    ]
+  },
+  "expect": {
+    "returncode": 0,
+    "responses_request_count": 1,
+    "responses": [
+      {
+        "request": 0,
+        "scope": "input",
+        "count": {
+          "### Available skills": 1,
+          "- implicit-skill: Implicit skill": 1,
+          "- manual-skill: Manual skill": 0
+        }
+      }
+    ]
+  },
+  "max_seconds": 30,
+  "timeout_seconds": 90
+}

--- a/tools/code-exec-harness/scenarios/project-doc-skill-dedup.json
+++ b/tools/code-exec-harness/scenarios/project-doc-skill-dedup.json
@@ -1,0 +1,36 @@
+{
+  "name": "project-doc-skill-dedup",
+  "model": "gpt-5.1-codex",
+  "prompt": "Reply with exactly: ok",
+  "files": {
+    "AGENTS.md": "# Harness Project Guidance\n\nKeep project guidance in context exactly once.\n",
+    ".codex/skills/demo/SKILL.md": "---\nname: demo\ndescription: Demo skill\n---\nUse the demo skill.\n",
+    "README.md": "# Project doc and skill dedup fixture\n"
+  },
+  "config_toml": "instructions = \"base guidance\"\n",
+  "responses_api": {
+    "responses": [
+      {
+        "response_id": "resp-dedup"
+      }
+    ]
+  },
+  "expect": {
+    "returncode": 0,
+    "responses_request_count": 1,
+    "responses": [
+      {
+        "request": 0,
+        "scope": "input",
+        "count": {
+          "# AGENTS.md instructions for": 1,
+          "Keep project guidance in context exactly once.": 1,
+          "### Available skills": 1,
+          "- demo: Demo skill": 1
+        }
+      }
+    ]
+  },
+  "max_seconds": 30,
+  "timeout_seconds": 90
+}


### PR DESCRIPTION
## Summary

This PR bundles the first token-efficiency fixes from the rollout/session friction audit:

- avoids duplicate pending tool outputs from being reintroduced after compaction
- prevents project docs and the skills manifest from being recomposed into user instructions multiple times
- adds real `code exec` harness coverage for prompt-shape/dedup behavior with fake `/v1/responses`
- documents the exec harness as the proving ground for effectiveness-adjusted token-efficiency work
- supports upstream-style manual-only skill policy via `policy.allow_implicit_invocation: false`
- injects explicitly requested `$skill-name` bodies request-only, without adding manual-only skills back to default context

Refs #46, #91, #92, #93.

## Validation

- `cargo test -p code-core project_doc::tests::does_not_recompose_rendered_project_docs_and_skills`
- `cargo test -p code-core project_doc::tests`
- `cargo test -p code-core --test prompt_context_dedup`
- `cargo test -p code-core skills::loader::tests::loads_skill_policy_from_frontmatter`
- `cargo test -p code-core skills::render::tests`
- `cargo test -p code-core codex::tests::selected_skill_messages_include_explicit_dollar_skill_once`
- `cargo test -p code-core user_instructions::tests::test_skill_instructions`
- `python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/project-doc-skill-dedup.json`
- `python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/manual-skill-not-implicit.json`
- `python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/manual-skill-explicit-invocation.json`
- `./build-fast.sh`
- `just local-code-rebuild`

JetBrains inspection note: targeted changed-file inspection routed to IntelliJ IDEA but returned `capture_incomplete` with zero shown problems, so it is inconclusive rather than a clean signal.
