### PR TITLE
Add request context source ledger

### DIFF
--- a/code-rs/core/src/client.rs
+++ b/code-rs/core/src/client.rs
@@ -886,6 +886,14 @@ impl ModelClient {
         let mut input_with_instructions = prompt.get_formatted_input();
         rewrite_image_generation_calls_for_input(&mut input_with_instructions);
         replace_image_payloads_for_model(&mut input_with_instructions, request_model);
+        let context_ledger =
+            prompt.context_ledger_for_request(&request_family, &input_with_instructions, &tools_json);
+        debug!(
+            target: "code_core::context_ledger",
+            summary = %context_ledger.compact_summary(),
+            entries = ?context_ledger.entries(),
+            "assembled context ledger for responses request"
+        );
 
         let want_format = prompt.text_format.clone().or_else(|| {
             prompt.output_schema.as_ref().map(|schema| crate::client_common::TextFormat {
@@ -1438,6 +1446,14 @@ impl ModelClient {
         let mut input_with_instructions = prompt.get_formatted_input();
         rewrite_image_generation_calls_for_input(&mut input_with_instructions);
         replace_image_payloads_for_model(&mut input_with_instructions, request_model);
+        let context_ledger =
+            prompt.context_ledger_for_request(&request_family, &input_with_instructions, &tools_json);
+        debug!(
+            target: "code_core::context_ledger",
+            summary = %context_ledger.compact_summary(),
+            entries = ?context_ledger.entries(),
+            "assembled context ledger for responses request"
+        );
 
         // Build `text` parameter with conditional verbosity and optional format.
         // - Omit entirely for ChatGPT auth unless a `text.format` or output schema is present.

--- a/code-rs/core/src/client_common.rs
+++ b/code-rs/core/src/client_common.rs
@@ -2,6 +2,10 @@ use crate::agent_defaults::model_guide_markdown;
 use crate::config_types::ReasoningEffort as ReasoningEffortConfig;
 use crate::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use crate::config_types::TextVerbosity as TextVerbosityConfig;
+use crate::context_ledger::ContextLedger;
+use crate::context_ledger::ContextPersistence;
+use crate::context_ledger::ContextSourceKind;
+use crate::context_ledger::response_item_bytes;
 use crate::environment_context::EnvironmentContext;
 use crate::error::Result;
 use crate::model_family::ModelFamily;
@@ -18,6 +22,9 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::task::Context;
@@ -163,10 +170,23 @@ impl Prompt {
     }
 
     pub(crate) fn get_formatted_input(&self) -> Vec<ResponseItem> {
+        self.get_formatted_input_with_ledger().0
+    }
+
+    pub(crate) fn get_formatted_input_with_ledger(&self) -> (Vec<ResponseItem>, ContextLedger) {
         let mut input_with_instructions =
             Vec::with_capacity(self.input.len() + self.status_items.len() + 3);
+        let mut ledger = ContextLedger::default();
         if self.include_additional_instructions {
             let developer_text = self.additional_instructions().into_owned();
+            ledger.push(
+                ContextSourceKind::DeveloperInstructions,
+                ContextPersistence::Contextual,
+                "default developer instructions",
+                1,
+                developer_text.len(),
+                Some("developer:default".to_string()),
+            );
             input_with_instructions.push(ResponseItem::Message {
                 id: None,
                 role: "developer".to_string(),
@@ -176,6 +196,14 @@ impl Prompt {
                 if trimmed.is_empty() {
                     continue;
                 }
+                ledger.push(
+                    classify_prepend_developer_message(trimmed),
+                    ContextPersistence::RequestOnly,
+                    "prepended developer message",
+                    1,
+                    trimmed.len(),
+                    Some(format!("developer:prepend:{:016x}", stable_hash(trimmed))),
+                );
                 input_with_instructions.push(ResponseItem::Message {
                     id: None,
                     role: "developer".to_string(),
@@ -192,6 +220,14 @@ impl Prompt {
                             )))
                 });
                 if !has_environment_context {
+                    ledger.push(
+                        ContextSourceKind::EnvironmentContext,
+                        ContextPersistence::GeneratedPerAttempt,
+                        "environment context",
+                        1,
+                        ec.len(),
+                        Some("environment_context".to_string()),
+                    );
                     input_with_instructions.push(ResponseItem::Message {
                         id: None,
                         role: "user".to_string(),
@@ -204,6 +240,7 @@ impl Prompt {
                         if role == "user" && UserInstructions::is_user_instructions(content))
                 });
                 if !has_user_instructions {
+                    add_response_item_to_ledger(&mut ledger, &ui);
                     input_with_instructions.push(ui);
                 }
             }
@@ -224,16 +261,78 @@ impl Prompt {
                 }
                 _ => {}
             }
+            add_response_item_to_ledger(&mut ledger, item);
             input_with_instructions.push(item.clone());
         }
 
         // Add status items at the end so they're fresh for each request
-        input_with_instructions.extend(self.status_items.clone());
+        for item in &self.status_items {
+            ledger.push(
+                classify_status_item(item),
+                ContextPersistence::GeneratedPerAttempt,
+                "status item",
+                1,
+                response_item_bytes(item),
+                duplicate_key_for_status_item(item),
+            );
+            input_with_instructions.push(item.clone());
+        }
 
         // Limit screenshots to maximum 5 (keep first and last 4)
         limit_screenshots_in_input(&mut input_with_instructions);
 
-        input_with_instructions
+        (input_with_instructions, ledger)
+    }
+
+    pub(crate) fn context_ledger_for_request(
+        &self,
+        model: &ModelFamily,
+        input: &[ResponseItem],
+        tools_json: &[serde_json::Value],
+    ) -> ContextLedger {
+        let mut ledger = self.context_ledger_for_formatted_input(input);
+        let full_instructions = self.get_full_instructions(model);
+        ledger.push(
+            ContextSourceKind::BaseInstructions,
+            ContextPersistence::Contextual,
+            "base instructions",
+            1,
+            full_instructions.len(),
+            Some("base_instructions".to_string()),
+        );
+
+        let tools_bytes = tools_json
+            .iter()
+            .map(|tool| serde_json::to_string(tool).map(|s| s.len()).unwrap_or(0))
+            .sum::<usize>();
+        ledger.push(
+            ContextSourceKind::ToolSchema,
+            ContextPersistence::Contextual,
+            "tool schemas",
+            tools_json.len(),
+            tools_bytes,
+            Some("tool_schemas".to_string()),
+        );
+        ledger
+    }
+
+    fn context_ledger_for_formatted_input(&self, input: &[ResponseItem]) -> ContextLedger {
+        let mut ledger = ContextLedger::default();
+        for item in input {
+            if self.status_items.iter().any(|status_item| status_item == item) {
+                ledger.push(
+                    classify_status_item(item),
+                    ContextPersistence::GeneratedPerAttempt,
+                    "status item",
+                    1,
+                    response_item_bytes(item),
+                    duplicate_key_for_status_item(item),
+                );
+                continue;
+            }
+            add_response_item_to_ledger(&mut ledger, item);
+        }
+        ledger
     }
 
     pub fn set_tools(&mut self, tools: Vec<OpenAiTool>) {
@@ -249,6 +348,211 @@ impl Prompt {
         }
         .into()
     }
+}
+
+fn classify_prepend_developer_message(text: &str) -> ContextSourceKind {
+    if text.contains("<memory") || text.to_ascii_lowercase().contains("memory") {
+        ContextSourceKind::MemoryInstructions
+    } else {
+        ContextSourceKind::DeveloperInstructions
+    }
+}
+
+fn add_response_item_to_ledger(ledger: &mut ContextLedger, item: &ResponseItem) {
+    if let ResponseItem::Message { role, content, .. } = item {
+        if role == "user" && UserInstructions::is_user_instructions(content) {
+            add_user_instructions_to_ledger(ledger, content);
+            return;
+        }
+    }
+
+    ledger.push(
+        classify_input_item(item),
+        persistence_for_input_item(item),
+        label_for_input_item(item),
+        1,
+        response_item_bytes(item),
+        duplicate_key_for_input_item(item),
+    );
+}
+
+fn add_user_instructions_to_ledger(ledger: &mut ContextLedger, content: &[ContentItem]) {
+    let text = content_text(content);
+    let skills_marker = "## Skills";
+    if let Some((project_docs, skills_manifest)) = text.split_once(skills_marker) {
+        ledger.push(
+            ContextSourceKind::UserInstructions,
+            ContextPersistence::Contextual,
+            "user/project instructions",
+            1,
+            project_docs.len(),
+            Some("user_instructions".to_string()),
+        );
+        ledger.push(
+            ContextSourceKind::SkillsManifest,
+            ContextPersistence::Contextual,
+            "skills manifest",
+            1,
+            skills_marker.len() + skills_manifest.len(),
+            Some("skills_manifest".to_string()),
+        );
+    } else {
+        ledger.push(
+            ContextSourceKind::UserInstructions,
+            ContextPersistence::Contextual,
+            "user/project instructions",
+            1,
+            text.len(),
+            Some("user_instructions".to_string()),
+        );
+    }
+}
+
+fn classify_input_item(item: &ResponseItem) -> ContextSourceKind {
+    match item {
+        ResponseItem::Message { role, content, .. } if role == "user" => {
+            classify_user_message(content)
+        }
+        ResponseItem::Message { role, .. } if role == "developer" => {
+            ContextSourceKind::DeveloperInstructions
+        }
+        ResponseItem::Message { .. } => ContextSourceKind::ConversationHistory,
+        ResponseItem::FunctionCallOutput { .. }
+        | ResponseItem::CustomToolCallOutput { .. }
+        | ResponseItem::ToolSearchOutput { .. } => ContextSourceKind::ToolOutput,
+        ResponseItem::FunctionCall { .. }
+        | ResponseItem::CustomToolCall { .. }
+        | ResponseItem::LocalShellCall { .. }
+        | ResponseItem::ToolSearchCall { .. }
+        | ResponseItem::WebSearchCall { .. }
+        | ResponseItem::ImageGenerationCall { .. } => ContextSourceKind::ConversationHistory,
+        ResponseItem::Reasoning { .. }
+        | ResponseItem::GhostSnapshot { .. }
+        | ResponseItem::CompactionSummary { .. }
+        | ResponseItem::ContextCompaction { .. } => ContextSourceKind::ConversationHistory,
+        ResponseItem::Other => ContextSourceKind::Unknown,
+    }
+}
+
+fn classify_user_message(content: &[ContentItem]) -> ContextSourceKind {
+    let text = content_text(content);
+    if text.starts_with("<skill>\n") {
+        ContextSourceKind::ExplicitSkill
+    } else if text.contains(ENVIRONMENT_CONTEXT_START.trim()) {
+        ContextSourceKind::EnvironmentContext
+    } else if UserInstructions::is_user_instructions(content) {
+        if text.contains("### Available skills") {
+            ContextSourceKind::SkillsManifest
+        } else {
+            ContextSourceKind::UserInstructions
+        }
+    } else if content
+        .iter()
+        .any(|item| matches!(item, ContentItem::InputImage { .. }))
+    {
+        ContextSourceKind::BrowserStatus
+    } else {
+        ContextSourceKind::ConversationHistory
+    }
+}
+
+fn classify_status_item(item: &ResponseItem) -> ContextSourceKind {
+    match item {
+        ResponseItem::Message { content, .. }
+            if content
+                .iter()
+                .any(|item| matches!(item, ContentItem::InputImage { .. })) =>
+        {
+            ContextSourceKind::BrowserStatus
+        }
+        _ => ContextSourceKind::StatusItem,
+    }
+}
+
+fn persistence_for_input_item(item: &ResponseItem) -> ContextPersistence {
+    match classify_input_item(item) {
+        ContextSourceKind::ExplicitSkill => ContextPersistence::RequestOnly,
+        ContextSourceKind::DeveloperInstructions
+        | ContextSourceKind::UserInstructions
+        | ContextSourceKind::SkillsManifest => ContextPersistence::Contextual,
+        ContextSourceKind::EnvironmentContext | ContextSourceKind::BrowserStatus => {
+            ContextPersistence::GeneratedPerAttempt
+        }
+        ContextSourceKind::ToolOutput => ContextPersistence::ToolResult,
+        _ => ContextPersistence::Persisted,
+    }
+}
+
+fn label_for_input_item(item: &ResponseItem) -> &'static str {
+    match classify_input_item(item) {
+        ContextSourceKind::ExplicitSkill => "explicit skill",
+        ContextSourceKind::EnvironmentContext => "environment context",
+        ContextSourceKind::BrowserStatus => "browser/status context",
+        ContextSourceKind::ToolOutput => "tool output",
+        ContextSourceKind::DeveloperInstructions => "developer message",
+        ContextSourceKind::UserInstructions => "user/project instructions",
+        ContextSourceKind::SkillsManifest => "skills manifest",
+        ContextSourceKind::ConversationHistory => "conversation history",
+        _ => "input item",
+    }
+}
+
+fn duplicate_key_for_input_item(item: &ResponseItem) -> Option<String> {
+    match item {
+        ResponseItem::Message { role, content, .. } if role == "user" => {
+            let source = classify_user_message(content);
+            match source {
+                ContextSourceKind::ExplicitSkill => skill_name_from_content(content)
+                    .map(|name| format!("explicit_skill:{name}"))
+                    .or_else(|| Some(format!("explicit_skill:{:016x}", stable_hash(&content_text(content))))),
+                ContextSourceKind::EnvironmentContext => Some("environment_context".to_string()),
+                ContextSourceKind::UserInstructions | ContextSourceKind::SkillsManifest => {
+                    Some("user_instructions".to_string())
+                }
+                _ => None,
+            }
+        }
+        ResponseItem::FunctionCallOutput { call_id, .. }
+        | ResponseItem::CustomToolCallOutput { call_id, .. } => Some(format!("tool_output:{call_id}")),
+        ResponseItem::ToolSearchOutput { call_id, .. } => {
+            call_id.as_ref().map(|call_id| format!("tool_output:{call_id}"))
+        }
+        _ => None,
+    }
+}
+
+fn duplicate_key_for_status_item(item: &ResponseItem) -> Option<String> {
+    match classify_status_item(item) {
+        ContextSourceKind::BrowserStatus => Some("browser_status".to_string()),
+        ContextSourceKind::StatusItem => Some(format!("status:{:016x}", stable_hash(&format!("{item:?}")))),
+        _ => None,
+    }
+}
+
+fn content_text(content: &[ContentItem]) -> String {
+    content
+        .iter()
+        .filter_map(|item| match item {
+            ContentItem::InputText { text } | ContentItem::OutputText { text } => {
+                Some(text.as_str())
+            }
+            ContentItem::InputImage { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn skill_name_from_content(content: &[ContentItem]) -> Option<String> {
+    let text = content_text(content);
+    text.lines()
+        .find_map(|line| line.strip_prefix("<name>")?.strip_suffix("</name>"))
+        .map(ToOwned::to_owned)
+}
+
+fn stable_hash(value: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
 }
 
 #[derive(Debug)]
@@ -572,10 +876,115 @@ impl Stream for ResponseStream {
 #[cfg(test)]
 mod tests {
     use crate::model_family::find_family_for_model;
+    use crate::context_ledger::ContextPersistence;
+    use crate::context_ledger::ContextSourceKind;
     use code_apply_patch::APPLY_PATCH_TOOL_INSTRUCTIONS;
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    fn message(role: &str, text: &str) -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: role.to_string(),
+            content: vec![ContentItem::InputText {
+                text: text.to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    #[test]
+    fn context_ledger_classifies_request_sources() {
+        let model_family = find_family_for_model("gpt-5.1").expect("model family");
+        let prompt = Prompt {
+            input: vec![
+                message("user", "hello"),
+                message(
+                    "user",
+                    "<skill>\n<name>manual-skill</name>\n<path>skills/manual/SKILL.md</path>\nbody\n</skill>",
+                ),
+                ResponseItem::FunctionCallOutput {
+                    call_id: "call-1".to_string(),
+                    output: code_protocol::models::FunctionCallOutputPayload::from_text(
+                        "tool output".to_string(),
+                    ),
+                },
+            ],
+            user_instructions: Some(
+                "project guidance\n\n## Skills\n### Available skills\n- demo: Demo skill".to_string(),
+            ),
+            status_items: vec![message("user", "status marker")],
+            include_additional_instructions: false,
+            ..Prompt::default()
+        };
+
+        let mut formatted = prompt.get_formatted_input();
+        rewrite_image_generation_calls_for_input(&mut formatted);
+        replace_image_payloads_for_model(&mut formatted, "gpt-5.1");
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "name": "demo_tool",
+            "parameters": {}
+        })];
+        let ledger = prompt.context_ledger_for_request(&model_family, &formatted, &tools);
+
+        assert!(ledger.total_bytes() > 0);
+        assert!(ledger.total_estimated_tokens() > 0);
+        assert!(ledger.entries().iter().any(|entry| {
+            entry.source == ContextSourceKind::BaseInstructions
+                && entry.persistence == ContextPersistence::Contextual
+        }));
+        assert!(ledger.entries().iter().any(|entry| {
+            entry.source == ContextSourceKind::ExplicitSkill
+                && entry.persistence == ContextPersistence::RequestOnly
+                && entry.duplicate_key.as_deref() == Some("explicit_skill:manual-skill")
+        }));
+        assert!(ledger.entries().iter().any(|entry| {
+            entry.source == ContextSourceKind::ToolOutput
+                && entry.persistence == ContextPersistence::ToolResult
+                && entry.duplicate_key.as_deref() == Some("tool_output:call-1")
+        }));
+        assert!(ledger.entries().iter().any(|entry| {
+            entry.source == ContextSourceKind::StatusItem
+                && entry.persistence == ContextPersistence::GeneratedPerAttempt
+        }));
+        assert!(ledger.entries().iter().any(|entry| {
+            entry.source == ContextSourceKind::ToolSchema
+                && entry.persistence == ContextPersistence::Contextual
+        }));
+    }
+
+    #[test]
+    fn context_ledger_sees_project_doc_skills_manifest() {
+        let prompt = Prompt {
+            user_instructions: Some(
+                "project guidance\n\n## Skills\n### Available skills\n- demo: Demo skill".to_string(),
+            ),
+            include_additional_instructions: true,
+            ..Prompt::default()
+        };
+
+        let (formatted, ledger) = prompt.get_formatted_input_with_ledger();
+
+        assert!(formatted.iter().any(|item| match item {
+            ResponseItem::Message { content, .. } => {
+                content.iter().any(|content| matches!(content,
+                    ContentItem::InputText { text } if text.contains("### Available skills")
+                ))
+            }
+            _ => false,
+        }));
+        assert!(ledger.entries().iter().any(|entry| {
+            entry.source == ContextSourceKind::UserInstructions
+                && entry.duplicate_key.as_deref() == Some("user_instructions")
+        }));
+        assert!(ledger.entries().iter().any(|entry| {
+            entry.source == ContextSourceKind::SkillsManifest
+                && entry.duplicate_key.as_deref() == Some("skills_manifest")
+        }));
+    }
 
     #[test]
     fn replace_image_payloads_for_spark_model_rewrites_images() {

--- a/code-rs/core/src/context_ledger.rs
+++ b/code-rs/core/src/context_ledger.rs
@@ -1,0 +1,254 @@
+use code_protocol::models::ContentItem;
+use code_protocol::models::FunctionCallOutputBody;
+use code_protocol::models::FunctionCallOutputContentItem;
+use code_protocol::models::ResponseItem;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+const ESTIMATED_BYTES_PER_TOKEN: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextSourceKind {
+    BaseInstructions,
+    DeveloperInstructions,
+    MemoryInstructions,
+    UserInstructions,
+    SkillsManifest,
+    ExplicitSkill,
+    EnvironmentContext,
+    BrowserStatus,
+    StatusItem,
+    ConversationHistory,
+    PendingInput,
+    ToolOutput,
+    ToolSchema,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextPersistence {
+    Persisted,
+    Contextual,
+    RequestOnly,
+    GeneratedPerAttempt,
+    ToolResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextLedgerEntry {
+    pub source: ContextSourceKind,
+    pub persistence: ContextPersistence,
+    pub label: String,
+    pub item_count: usize,
+    pub bytes: usize,
+    pub estimated_tokens: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duplicate_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextLedger {
+    entries: Vec<ContextLedgerEntry>,
+}
+
+impl ContextLedger {
+    pub fn entries(&self) -> &[ContextLedgerEntry] {
+        &self.entries
+    }
+
+    pub fn push(
+        &mut self,
+        source: ContextSourceKind,
+        persistence: ContextPersistence,
+        label: impl Into<String>,
+        item_count: usize,
+        bytes: usize,
+        duplicate_key: Option<String>,
+    ) {
+        if item_count == 0 && bytes == 0 {
+            return;
+        }
+
+        self.entries.push(ContextLedgerEntry {
+            source,
+            persistence,
+            label: label.into(),
+            item_count,
+            bytes,
+            estimated_tokens: estimate_tokens(bytes),
+            duplicate_key,
+        });
+    }
+
+    pub fn total_bytes(&self) -> usize {
+        self.entries.iter().map(|entry| entry.bytes).sum()
+    }
+
+    pub fn total_estimated_tokens(&self) -> usize {
+        estimate_tokens(self.total_bytes())
+    }
+
+    pub fn compact_summary(&self) -> String {
+        let mut totals: BTreeMap<ContextSourceKind, (usize, usize)> = BTreeMap::new();
+        for entry in &self.entries {
+            let aggregate = totals.entry(entry.source).or_default();
+            aggregate.0 = aggregate.0.saturating_add(entry.item_count);
+            aggregate.1 = aggregate.1.saturating_add(entry.bytes);
+        }
+
+        let mut parts = Vec::new();
+        for (source, (items, bytes)) in totals {
+            parts.push(format!(
+                "{source:?}:items={items},bytes={bytes},tokens~{}",
+                estimate_tokens(bytes)
+            ));
+        }
+        format!(
+            "total_bytes={},total_tokens~{} [{}]",
+            self.total_bytes(),
+            self.total_estimated_tokens(),
+            parts.join("; ")
+        )
+    }
+}
+
+pub fn estimate_tokens(bytes: usize) -> usize {
+    bytes.saturating_add(ESTIMATED_BYTES_PER_TOKEN - 1) / ESTIMATED_BYTES_PER_TOKEN
+}
+
+pub fn response_item_bytes(item: &ResponseItem) -> usize {
+    match item {
+        ResponseItem::Message { role, content, .. } => {
+            role.len() + content.iter().map(content_item_bytes).sum::<usize>()
+        }
+        ResponseItem::Reasoning {
+            summary,
+            content,
+            encrypted_content,
+            ..
+        } => {
+            summary
+                .iter()
+                .map(|summary| match summary {
+                    code_protocol::models::ReasoningItemReasoningSummary::SummaryText {
+                        text,
+                    } => text.len(),
+                })
+                .sum::<usize>()
+                + content
+                    .as_ref()
+                    .map(|content| {
+                        content
+                            .iter()
+                            .map(|item| match item {
+                                code_protocol::models::ReasoningItemContent::ReasoningText {
+                                    text,
+                                }
+                                | code_protocol::models::ReasoningItemContent::Text { text } => {
+                                    text.len()
+                                }
+                            })
+                            .sum::<usize>()
+                    })
+                    .unwrap_or(0)
+                + encrypted_content.as_ref().map(String::len).unwrap_or(0)
+        }
+        ResponseItem::LocalShellCall {
+            call_id, action, ..
+        } => call_id.as_ref().map(String::len).unwrap_or(0) + format!("{action:?}").len(),
+        ResponseItem::FunctionCall {
+            name,
+            namespace,
+            arguments,
+            call_id,
+            ..
+        } => {
+            name.len()
+                + namespace.as_ref().map(String::len).unwrap_or(0)
+                + arguments.len()
+                + call_id.len()
+        }
+        ResponseItem::ToolSearchCall {
+            call_id,
+            status,
+            execution,
+            arguments,
+            ..
+        } => {
+            call_id.as_ref().map(String::len).unwrap_or(0)
+                + status.as_ref().map(String::len).unwrap_or(0)
+                + execution.len()
+                + serde_json::to_string(arguments).map(|s| s.len()).unwrap_or(0)
+        }
+        ResponseItem::FunctionCallOutput { call_id, output } => {
+            call_id.len() + function_call_output_bytes(&output.body)
+        }
+        ResponseItem::CustomToolCall {
+            call_id,
+            name,
+            input,
+            ..
+        } => call_id.len() + name.len() + input.len(),
+        ResponseItem::CustomToolCallOutput {
+            call_id,
+            name,
+            output,
+        } => {
+            call_id.len()
+                + name.as_ref().map(String::len).unwrap_or(0)
+                + function_call_output_bytes(&output.body)
+        }
+        ResponseItem::ToolSearchOutput {
+            call_id,
+            status,
+            execution,
+            tools,
+        } => {
+            call_id.as_ref().map(String::len).unwrap_or(0)
+                + status.len()
+                + execution.len()
+                + serde_json::to_string(tools).map(|s| s.len()).unwrap_or(0)
+        }
+        ResponseItem::WebSearchCall { status, action, .. } => {
+            status.as_ref().map(String::len).unwrap_or(0)
+                + serde_json::to_string(action).map(|s| s.len()).unwrap_or(0)
+        }
+        ResponseItem::ImageGenerationCall {
+            status,
+            revised_prompt,
+            result,
+            ..
+        } => status.len() + revised_prompt.as_ref().map(String::len).unwrap_or(0) + result.len(),
+        ResponseItem::GhostSnapshot { ghost_commit } => {
+            serde_json::to_string(ghost_commit).map(|s| s.len()).unwrap_or(0)
+        }
+        ResponseItem::CompactionSummary { encrypted_content } => encrypted_content.len(),
+        ResponseItem::ContextCompaction { encrypted_content } => {
+            encrypted_content.as_ref().map(String::len).unwrap_or(0)
+        }
+        ResponseItem::Other => 0,
+    }
+}
+
+pub fn content_item_bytes(item: &ContentItem) -> usize {
+    match item {
+        ContentItem::InputText { text } | ContentItem::OutputText { text } => text.len(),
+        ContentItem::InputImage { image_url } => image_url.len(),
+    }
+}
+
+fn function_call_output_bytes(body: &FunctionCallOutputBody) -> usize {
+    match body {
+        FunctionCallOutputBody::Text(text) => text.len(),
+        FunctionCallOutputBody::ContentItems(items) => items
+            .iter()
+            .map(|item| match item {
+                FunctionCallOutputContentItem::InputText { text } => text.len(),
+                FunctionCallOutputContentItem::InputImage { image_url, .. } => image_url.len(),
+            })
+            .sum(),
+    }
+}

--- a/code-rs/core/src/lib.rs
+++ b/code-rs/core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod config_edit;
 pub mod config_profile;
 pub mod config_types;
 mod config_loader;
+mod context_ledger;
 mod conversation_history;
 pub mod context_timeline;
 pub mod acp;

--- a/tools/code-exec-harness/harness.py
+++ b/tools/code-exec-harness/harness.py
@@ -789,6 +789,15 @@ def assert_expectations(summary: dict[str, Any], scenario: dict[str, Any]) -> li
         text = "\n".join(" ".join(call.get("argv", [])) for call in summary.get("gh_calls", []))
         if str(needle) not in text:
             failures.append(f"no fake gh call contained {needle!r}")
+    stderr_log = ""
+    run_dir = summary.get("run_dir")
+    if isinstance(run_dir, str):
+        stderr_path = Path(run_dir) / "artifacts" / "stderr.log"
+        if stderr_path.exists():
+            stderr_log = read_text(stderr_path)
+    for needle in expect.get("stderr_contains", []):
+        if str(needle) not in stderr_log:
+            failures.append(f"stderr log did not contain {needle!r}")
     if "returncode" in expect and int(expect["returncode"]) != int(summary.get("returncode", -1)):
         failures.append(f"returncode expected {expect['returncode']}, got {summary.get('returncode')}")
     if "responses_request_count" in expect:

--- a/tools/code-exec-harness/scenarios/context-ledger-request-summary.json
+++ b/tools/code-exec-harness/scenarios/context-ledger-request-summary.json
@@ -1,0 +1,46 @@
+{
+  "name": "context-ledger-request-summary",
+  "model": "gpt-5.1-codex",
+  "prompt": "Use $manual-skill and reply with exactly: ok",
+  "files": {
+    "AGENTS.md": "project guidance\n",
+    ".codex/skills/implicit/SKILL.md": "---\nname: implicit-skill\ndescription: Implicit skill\n---\nUse the implicit skill.\n",
+    ".codex/skills/manual/SKILL.md": "---\nname: manual-skill\ndescription: Manual skill\npolicy:\n  allow_implicit_invocation: false\n---\nMANUAL_SKILL_BODY_MARKER\n",
+    "README.md": "# Context ledger fixture\n"
+  },
+  "env": {
+    "RUST_LOG": "code_core::context_ledger=debug"
+  },
+  "responses_api": {
+    "responses": [
+      {
+        "response_id": "resp-context-ledger"
+      }
+    ]
+  },
+  "expect": {
+    "returncode": 0,
+    "responses_request_count": 1,
+    "stderr_contains": [
+      "assembled context ledger for responses request",
+      "SkillsManifest",
+      "ExplicitSkill",
+      "ToolSchema"
+    ],
+    "responses": [
+      {
+        "request": 0,
+        "scope": "input",
+        "count": {
+          "project guidance": 1,
+          "- implicit-skill: Implicit skill": 1,
+          "- manual-skill: Manual skill": 0,
+          "<name>manual-skill</name>": 1,
+          "MANUAL_SKILL_BODY_MARKER": 1
+        }
+      }
+    ]
+  },
+  "max_seconds": 30,
+  "timeout_seconds": 90
+}


### PR DESCRIPTION
## Summary

Adds the first #92 context observability slice:

- introduces a core `ContextLedger` with source kind, persistence class, labels, item count, byte estimate, approximate token estimate, and duplicate keys
- computes the ledger from the final formatted Responses request input, plus base instructions and tool schemas
- logs a compact ledger summary and detailed entries through `code_core::context_ledger` before Responses requests are sent
- splits project/user instructions from the rendered skills manifest so future `/context` views can show skill catalog cost separately
- classifies explicit `$skill` injections as request-only context
- adds fake Responses harness coverage proving the executable path logs ledger categories while the actual request body contains the expected project docs, implicit skills catalog, and explicit manual skill body

Refs #92, #93.

## Validation

- `cargo test -p code-core client_common::tests::context_ledger`
- `cargo test -p code-core --test prompt_context_dedup`
- `python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/context-ledger-request-summary.json --code-bin /Users/cbusillo/Developer/code/code-rs/target/debug/code`
- `./build-fast.sh`
- `python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/context-ledger-request-summary.json --code-bin /Users/cbusillo/Developer/code/.code/working/_target-cache/code/feat-context-source-ledger-be2596d583c8-2af88e04f956/code-rs/dev-fast/code`
