### PR TITLE
feat(tui/context): show request context ledger

### DIFF
--- a/code-rs/core/src/chat_completions.rs
+++ b/code-rs/core/src/chat_completions.rs
@@ -1076,6 +1076,9 @@ where
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(None) => return Poll::Ready(None),
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+                Poll::Ready(Some(Ok(ResponseEvent::ContextLedger(ledger)))) => {
+                    return Poll::Ready(Some(Ok(ResponseEvent::ContextLedger(ledger))));
+                }
                 Poll::Ready(Some(Ok(ResponseEvent::OutputItemDone { item, sequence_number: _, .. }))) => {
                     // If this is an incremental assistant message chunk, accumulate but
                     // do NOT emit yet. Forward any other item (e.g. FunctionCall) right
@@ -1309,4 +1312,41 @@ fn header_map_to_json(headers: &HeaderMap) -> serde_json::Value {
     }
 
     serde_json::to_value(ordered).unwrap_or(serde_json::Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context_ledger::ContextLedger;
+    use crate::context_ledger::ContextPersistence;
+    use crate::context_ledger::ContextSourceKind;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn aggregate_forwards_context_ledger() {
+        let mut ledger = ContextLedger::default();
+        ledger.push(
+            ContextSourceKind::ToolSchema,
+            ContextPersistence::Contextual,
+            "tool schemas",
+            1,
+            40,
+            Some("tools".to_string()),
+        );
+        let stream = stream::iter(vec![
+            Ok(ResponseEvent::ContextLedger(ledger.clone())),
+            Ok(ResponseEvent::Completed {
+                response_id: "resp".to_string(),
+                token_usage: None,
+            }),
+        ]);
+
+        let events = stream.aggregate().collect::<Vec<_>>().await;
+
+        match &events[0] {
+            Ok(ResponseEvent::ContextLedger(observed)) => assert_eq!(observed, &ledger),
+            other => panic!("unexpected first event: {other:?}"),
+        }
+        assert!(matches!(events[1], Ok(ResponseEvent::Completed { .. })));
+    }
 }

--- a/code-rs/core/src/chat_completions.rs
+++ b/code-rs/core/src/chat_completions.rs
@@ -344,6 +344,13 @@ pub(crate) async fn stream_chat_completions(
     }
 
     let tools_json = create_tools_json_for_chat_completions_api(&prompt.tools)?;
+    let context_ledger = prompt.context_ledger_for_request(model_family, &input, &tools_json);
+    debug!(
+        target: "code_core::context_ledger",
+        summary = %context_ledger.compact_summary(),
+        entries = ?context_ledger.entries(),
+        "assembled context ledger for chat completions request"
+    );
     let mut payload = json!({
         "model": model_slug,
         "messages": messages,
@@ -451,6 +458,9 @@ pub(crate) async fn stream_chat_completions(
                     );
                 }
                 let (tx_event, rx_event) = mpsc::channel::<Result<ResponseEvent>>(1600);
+                let _ = tx_event
+                    .send(Ok(ResponseEvent::ContextLedger(context_ledger.clone())))
+                    .await;
                 let stream = resp.bytes_stream().map_err(CodexErr::Reqwest);
                 let debug_logger_clone = Arc::clone(&debug_logger);
                 let request_id_clone = request_id.clone();

--- a/code-rs/core/src/client.rs
+++ b/code-rs/core/src/client.rs
@@ -1118,6 +1118,9 @@ impl ModelClient {
             )?;
 
             let (tx_event, rx_event) = mpsc::channel::<Result<ResponseEvent>>(1600);
+            let _ = tx_event
+                .send(Ok(ResponseEvent::ContextLedger(context_ledger.clone())))
+                .await;
             let mut session = self.websocket_session.lock().await;
             if session.connection.is_none() {
                 let connect = timeout(
@@ -1702,6 +1705,9 @@ impl ModelClient {
                         );
                     }
                     let (tx_event, rx_event) = mpsc::channel::<Result<ResponseEvent>>(1600);
+                    let _ = tx_event
+                        .send(Ok(ResponseEvent::ContextLedger(context_ledger.clone())))
+                        .await;
 
                     let response_headers = header_map_to_json(resp.headers());
                     if tx_event

--- a/code-rs/core/src/client_common.rs
+++ b/code-rs/core/src/client_common.rs
@@ -557,6 +557,7 @@ fn stable_hash(value: &str) -> u64 {
 
 #[derive(Debug)]
 pub enum ResponseEvent {
+    ContextLedger(ContextLedger),
     Created {
         response_id: Option<String>,
         response_model: Option<String>,

--- a/code-rs/core/src/codex/streaming.rs
+++ b/code-rs/core/src/codex/streaming.rs
@@ -4135,6 +4135,10 @@ async fn try_run_turn(
         };
 
         match event {
+            ResponseEvent::ContextLedger(ledger) => {
+                let msg = EventMsg::ContextLedger(crate::protocol::ContextLedgerEvent { ledger });
+                sess.send_event(sess.make_event(&sub_id, msg)).await;
+            }
             ResponseEvent::Created {
                 response_id,
                 response_model,

--- a/code-rs/core/src/lib.rs
+++ b/code-rs/core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod config_edit;
 pub mod config_profile;
 pub mod config_types;
 mod config_loader;
-mod context_ledger;
+pub mod context_ledger;
 mod conversation_history;
 pub mod context_timeline;
 pub mod acp;

--- a/code-rs/core/src/protocol.rs
+++ b/code-rs/core/src/protocol.rs
@@ -27,6 +27,7 @@ use crate::config_types::TextVerbosity as TextVerbosityConfig;
 use crate::message_history::HistoryEntry;
 use crate::model_provider_info::ModelProviderInfo;
 use crate::client_common::TextFormat;
+use crate::context_ledger::ContextLedger;
 use crate::parse_command::ParsedCommand;
 use crate::plan_tool::UpdatePlanArgs;
 use code_protocol::dynamic_tools::DynamicToolCallRequest;
@@ -893,6 +894,9 @@ pub enum EventMsg {
     /// Auto Context is evaluating whether to compact before the next turn.
     AutoContextCheck(AutoContextCheckEvent),
 
+    /// Request composition ledger for the latest model request.
+    ContextLedger(ContextLedgerEvent),
+
     /// Agent text output message
     AgentMessage(AgentMessageEvent),
 
@@ -1077,6 +1081,11 @@ pub enum AutoContextPhase {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AutoContextCheckEvent {
     pub phase: Option<AutoContextPhase>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ContextLedgerEvent {
+    pub ledger: ContextLedger,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]

--- a/code-rs/exec/src/event_processor_with_human_output.rs
+++ b/code-rs/exec/src/event_processor_with_human_output.rs
@@ -760,6 +760,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 }
             }
             EventMsg::CompactionCheckpointWarning(_) => {}
+            EventMsg::ContextLedger(_) => {}
             EventMsg::ImageGenerationBegin(_) | EventMsg::ImageGenerationEnd(_) => {}
         }
         CodexStatus::Running

--- a/code-rs/mcp-server/src/code_tool_runner.rs
+++ b/code-rs/mcp-server/src/code_tool_runner.rs
@@ -317,6 +317,7 @@ async fn run_code_tool_session_inner(
                     | EventMsg::TaskStarted
                     | EventMsg::TokenCount(_)
                     | EventMsg::AutoContextCheck(_)
+                    | EventMsg::ContextLedger(_)
                     | EventMsg::AgentReasoning(_)
                     | EventMsg::AgentReasoningSectionBreak(_)
                     | EventMsg::McpToolCallBegin(_)

--- a/code-rs/tui/src/app/events.rs
+++ b/code-rs/tui/src/app/events.rs
@@ -1353,6 +1353,11 @@ impl App<'_> {
                                 widget.add_status_output();
                             }
                         }
+                        SlashCommand::Context => {
+                            if let AppState::Chat { widget } = &mut self.app_state {
+                                widget.add_context_output();
+                            }
+                        }
                         SlashCommand::Limits => {
                             if let AppState::Chat { widget } = &mut self.app_state {
                                 widget.handle_limits_command(command_args);

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -14526,6 +14526,7 @@ impl ChatWidget<'_> {
                 // after every tool call.
                 self.turn_sequence = self.turn_sequence.saturating_add(1);
                 self.turn_had_code_edits = false;
+                self.latest_context_ledger = None;
                 self.current_task_lifecycle = self.pending_task_lifecycle.take();
                 self.current_turn_origin = if self.current_task_output_is_hidden() {
                     Some(TurnOrigin::Developer)

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -43,6 +43,9 @@ use code_core::config_types::Notifications;
 use code_core::config_types::ReasoningEffort;
 use code_core::config_types::ServiceTier;
 use code_core::config_types::TextVerbosity;
+use code_core::context_ledger::ContextLedger;
+use code_core::context_ledger::ContextPersistence;
+use code_core::context_ledger::ContextSourceKind;
 use code_core::spawn::spawn_background_command_with_retry;
 use code_core::plan_tool::{PlanItemArg, StepStatus, UpdatePlanArgs};
 use code_core::model_family::derive_default_model_family;
@@ -1923,6 +1926,7 @@ pub(crate) struct ChatWidget<'a> {
     rate_limit_refresh_scheduled_for: Option<DateTime<Utc>>,
     rate_limit_refresh_schedule_id: Arc<AtomicU64>,
     rate_limit_refresh_task: Option<task::JoinHandle<()>>,
+    latest_context_ledger: Option<ContextLedger>,
     content_buffer: String,
     // Buffer for streaming assistant answer text; we do not surface partial
     // We wait for the final AgentMessage event and then emit the full text
@@ -7038,6 +7042,7 @@ impl ChatWidget<'_> {
             rate_limit_refresh_scheduled_for: None,
             rate_limit_refresh_schedule_id: Arc::new(AtomicU64::new(0)),
             rate_limit_refresh_task: None,
+            latest_context_ledger: None,
             content_buffer: String::new(),
             last_assistant_message: None,
             last_answer_stream_id_in_turn: None,
@@ -7413,6 +7418,7 @@ impl ChatWidget<'_> {
             rate_limit_refresh_scheduled_for: None,
             rate_limit_refresh_schedule_id: Arc::new(AtomicU64::new(0)),
             rate_limit_refresh_task: None,
+            latest_context_ledger: None,
             content_buffer: String::new(),
             last_assistant_message: None,
             last_answer_stream_id_in_turn: None,
@@ -14824,6 +14830,9 @@ impl ChatWidget<'_> {
                 }
                 self.bottom_pane.set_auto_context_phase(event.phase);
             }
+            EventMsg::ContextLedger(event) => {
+                self.latest_context_ledger = Some(event.ledger);
+            }
             EventMsg::Warning(WarningEvent { message }) => {
                 self.history_push_plain_state(history_cell::new_warning_event(message));
                 self.request_redraw();
@@ -16911,6 +16920,124 @@ impl ChatWidget<'_> {
             self.session_requested_model.as_deref(),
             self.session_latest_response_model.as_deref(),
         ));
+    }
+
+    pub(crate) fn add_context_output(&mut self) {
+        let state = match self.latest_context_ledger.as_ref() {
+            Some(ledger) => Self::context_ledger_message_state(ledger),
+            None => history_cell::plain_message_state_from_lines(
+                vec![
+                    Line::from("/context").fg(crate::colors::keyword()),
+                    Line::from(""),
+                    Line::from("No request context ledger is available yet."),
+                ],
+                HistoryCellType::Notice,
+            ),
+        };
+        self.history_push_plain_state(state);
+    }
+
+    fn context_ledger_message_state(ledger: &ContextLedger) -> PlainMessageState {
+        let lines = Self::context_ledger_display_lines(ledger)
+            .into_iter()
+            .map(Line::from)
+            .collect::<Vec<_>>();
+        history_cell::plain_message_state_from_lines(lines, HistoryCellType::Notice)
+    }
+
+    fn context_ledger_display_lines(ledger: &ContextLedger) -> Vec<String> {
+        let mut rows = ledger
+            .entries()
+            .iter()
+            .map(|entry| {
+                (
+                    Self::source_label(entry.source),
+                    Self::persistence_label(entry.persistence),
+                    entry.label.as_str(),
+                    entry.item_count,
+                    entry.bytes,
+                    entry.estimated_tokens,
+                )
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| right.5.cmp(&left.5).then_with(|| left.0.cmp(right.0)));
+
+        let mut lines = Vec::new();
+        lines.push("/context".to_string());
+        lines.push(String::new());
+        lines.push(format!(
+            "Total: ~{} tokens, {}",
+            format_with_separators_u64(ledger.total_estimated_tokens() as u64),
+            Self::format_context_bytes(ledger.total_bytes()),
+        ));
+        lines.push(String::new());
+        lines.push(format!(
+            "{:<24} {:>10} {:>9} {:<14} {}",
+            "Source", "Tokens", "Bytes", "Persistence", "Label"
+        ));
+
+        for (source, persistence, label, item_count, bytes, tokens) in rows.into_iter().take(12) {
+            let item_suffix = if item_count > 1 {
+                format!(" ({item_count} items)")
+            } else {
+                String::new()
+            };
+            lines.push(format!(
+                "{:<24} {:>10} {:>9} {:<14} {}{}",
+                source,
+                format!("~{}", format_with_separators_u64(tokens as u64)),
+                Self::format_context_bytes(bytes),
+                persistence,
+                label,
+                item_suffix,
+            ));
+        }
+        if ledger.entries().len() > 12 {
+            lines.push(format!(
+                "... {} more entries",
+                ledger.entries().len().saturating_sub(12)
+            ));
+        }
+        lines
+    }
+
+    fn format_context_bytes(bytes: usize) -> String {
+        if bytes >= 1024 * 1024 {
+            format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+        } else if bytes >= 1024 {
+            format!("{:.1} KB", bytes as f64 / 1024.0)
+        } else {
+            format!("{bytes} B")
+        }
+    }
+
+    fn source_label(source: ContextSourceKind) -> &'static str {
+        match source {
+            ContextSourceKind::BaseInstructions => "base instructions",
+            ContextSourceKind::DeveloperInstructions => "developer instructions",
+            ContextSourceKind::MemoryInstructions => "memory",
+            ContextSourceKind::UserInstructions => "user instructions",
+            ContextSourceKind::SkillsManifest => "skills manifest",
+            ContextSourceKind::ExplicitSkill => "explicit skill",
+            ContextSourceKind::EnvironmentContext => "environment",
+            ContextSourceKind::BrowserStatus => "browser status",
+            ContextSourceKind::StatusItem => "status item",
+            ContextSourceKind::ConversationHistory => "history",
+            ContextSourceKind::PendingInput => "pending input",
+            ContextSourceKind::ToolOutput => "tool output",
+            ContextSourceKind::ToolSchema => "tool schema",
+            ContextSourceKind::Unknown => "unknown",
+        }
+    }
+
+    fn persistence_label(persistence: ContextPersistence) -> &'static str {
+        match persistence {
+            ContextPersistence::Persisted => "persisted",
+            ContextPersistence::Contextual => "contextual",
+            ContextPersistence::RequestOnly => "request-only",
+            ContextPersistence::GeneratedPerAttempt => "per-attempt",
+            ContextPersistence::ToolResult => "tool-result",
+        }
     }
 
     pub(crate) fn show_limits_settings_ui(&mut self) {
@@ -31692,6 +31819,43 @@ use code_core::protocol::OrderMeta;
                 other => panic!("expected UserInput, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn context_ledger_display_sorts_by_token_weight() {
+        let mut ledger = ContextLedger::default();
+        ledger.push(
+            ContextSourceKind::ToolSchema,
+            ContextPersistence::Contextual,
+            "tool schemas",
+            2,
+            800,
+            Some("tools".to_string()),
+        );
+        ledger.push(
+            ContextSourceKind::ConversationHistory,
+            ContextPersistence::Persisted,
+            "history item",
+            1,
+            4_096,
+            Some("history".to_string()),
+        );
+
+        let lines = ChatWidget::context_ledger_display_lines(&ledger);
+
+        assert_eq!(lines[0], "/context");
+        assert!(lines[2].contains("~1,224 tokens"));
+        let history_row = lines
+            .iter()
+            .position(|line| line.contains("history"))
+            .expect("history row");
+        let tool_row = lines
+            .iter()
+            .position(|line| line.contains("tool schema"))
+            .expect("tool schema row");
+        assert!(history_row < tool_row);
+        assert!(lines[history_row].contains("persisted"));
+        assert!(lines[tool_row].contains("contextual"));
     }
 
     fn test_rate_limit_snapshot() -> RateLimitSnapshotEvent {

--- a/code-rs/tui/src/slash_command.rs
+++ b/code-rs/tui/src/slash_command.rs
@@ -64,6 +64,7 @@ pub enum SlashCommand {
     Mention,
     Cmd,
     Status,
+    Context,
     Limits,
     #[strum(serialize = "update", serialize = "upgrade")]
     Update,
@@ -125,6 +126,7 @@ impl SlashCommand {
             SlashCommand::Mention => "mention a file",
             SlashCommand::Cmd => "run a project command",
             SlashCommand::Status => "show current session configuration and token usage",
+            SlashCommand::Context => "show request context composition",
             SlashCommand::Limits => "adjust session limits",
             SlashCommand::Update => "check for updates and optionally upgrade",
             SlashCommand::Notifications => "manage notification settings",


### PR DESCRIPTION
## Summary

- add a core/TUI `ContextLedger` event so the latest real request ledger reaches the chat widget
- add `/context` to show the last request's total estimated context and source rows sorted by estimated tokens
- forward the ledger through chat-completion aggregation and ignore it in non-UI event consumers

## Validation

- `cargo test -p code-tui context_ledger_display_sorts_by_token_weight --features test-helpers`
- `cargo test -p code-core chat_completions::tests::aggregate_forwards_context_ledger`
- `./build-fast.sh`

## Notes

JetBrains inspection was attempted with `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`; it routed to IntelliJ IDEA for this repo but returned `capture_incomplete` with zero shown problems, so there is no clean IDE inspection receipt for this branch.

Refs #93
Refs #92
