### PR TITLE
docs: reframe Every Code product identity

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -1,12 +1,12 @@
 {
   "defaultBranch": "local/cbusillo-overlay",
-  "projectType": "codex-cli-local-overlay",
+  "projectType": "every-code-product",
   "upstreamForkBaseBranch": "fork-main",
   "overlayBranch": "local/cbusillo-overlay",
   "docs": {
     "overview": "README.md",
     "agentGuide": "AGENTS.md",
-    "localOverlay": "docs/local-overlay.md",
+    "upstreamImportPolicy": "docs/local-overlay.md",
     "execution": "docs/exec.md",
     "sandboxing": "docs/platform-sandboxing.md",
     "tuiComposer": "docs/tui-chat-composer.md",
@@ -36,7 +36,8 @@
       "TUI behavior changes",
       "sandbox or execution behavior changes",
       "release behavior changes",
-      "local overlay behavior changes",
+      "Every Code product identity changes",
+      "upstream import policy changes",
       "Every Code remote inbox behavior changes",
       "upstream mirror behavior changes"
     ]
@@ -97,7 +98,7 @@
       "repo relationship changes",
       "cleanup policy changes",
       "GitHub default branch changes",
-      "overlay branch changes",
+      "Every Code default branch changes",
       "release workflow changes",
       "upstream mirror policy changes"
     ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,16 @@
-# Rust/codex-rs
+# Every Code Repository Guidance
 
 Repo workflow metadata lives in `.github/github.json`; keep that
 file aligned with branch roles, validation gates, GitHub signal capabilities,
 workflow names, docs routing, and local cleanup policy when those facts change.
 
-In the codex-rs folder where the rust code lives:
+Every Code is the product in this repository; `code` is the CLI shorthand.
+Upstream Codex and just-every/code are provenance and import sources, not the
+repo's product identity.
 
-- Crate names are prefixed with `codex-`. For example, the `core` folder's crate is named `codex-core`
+Rust implementation lives under `code-rs`:
+
+- Crate names are prefixed with `code-`. For example, the `core` folder's crate is named `code-core`.
 - When using format! and you can inline variables into {}, always do that.
 - Treat `codex-rs` as a read-only mirror of `openai/codex:main`; edit Rust sources under `code-rs` instead.
 
@@ -60,21 +64,21 @@ Examples:
 - `fix(core/codex): handle SIGINT in on_exec_command_begin to avoid orphaned child`
 - `docs(agents): clarify commit-message expectations`
 
-## Local Overlay Workflow
+## Upstream Import Workflow
 
-- The canonical local-carry branch is `local/cbusillo-overlay`. Treat it as the source of truth for the `code` binary installed on this machine.
+- Until #87 renames the default branch, `local/cbusillo-overlay` is the canonical Every Code branch and source of truth for the `code` binary installed on this machine.
 - Use `just local-code-rebuild` to rebuild the current branch into the PATH-resolved binary.
 - After `./build-fast.sh`, run `just local-code-rebuild` again before release smoke checks; the fast build can leave the PATH-resolved `code` pointing at a dev-fast binary that reports `0.0.0`.
 - Before leaving a local work session, run `just local-cleanup-space --apply`
   to remove rebuildable target/cache artifacts while preserving
   `code-rs/target/release/code`.
-- Use `just local-overlay-update` only from a clean `local/*` branch. It fetches `upstream/main`, merges it into the current overlay branch, replays any commits listed in `scripts/local/overlay-picks.txt`, then rebuilds the release binary.
-- Commits already on `local/cbusillo-overlay` persist automatically across future upstream merges. They do not need to be duplicated in `scripts/local/overlay-picks.txt`.
-- If you make a new local fix that should remain part of the carried overlay, commit it onto `local/cbusillo-overlay` first. Do not leave important local changes only as an unmerged side branch.
+- Use `just local-overlay-update` only from a clean `local/*` branch. It fetches `upstream/main`, merges it into the current Every Code branch, replays any commits listed in `scripts/local/overlay-picks.txt`, then rebuilds the release binary.
+- Commits already on `local/cbusillo-overlay` persist automatically across future upstream imports. They do not need to be duplicated in `scripts/local/overlay-picks.txt`.
+- If you make a new Every Code fix that should remain part of the product, commit it through the normal task-branch/PR flow into `local/cbusillo-overlay` first. Do not leave important local changes only as an unmerged side branch.
 - Add a commit SHA to `scripts/local/overlay-picks.txt` only for a patch that intentionally lives outside the overlay branch and still needs to be cherry-picked in during `just local-overlay-update`. Keep the list ordered and comment each entry with the source branch or purpose.
 - Old side branches are archival context, not the runtime source of truth. They do not need to merge cleanly as branches; only the specific carried commits must cherry-pick cleanly onto the current overlay branch.
 - If a legacy pick no longer cherry-picks cleanly, leave it commented out in `scripts/local/overlay-picks.txt`, manually re-port the fix against current upstream, commit the new port on `local/cbusillo-overlay`, then replace the old SHA in the manifest if you still want automatic replay.
-- For overlay-owned surfaces, release steps, remote names, and conflict hot spots, see `docs/local-overlay.md`.
+- For Every Code-owned surfaces, release steps, remote names, and conflict hot spots, see `docs/local-overlay.md`.
 
 ## How to Git Push
 
@@ -103,18 +107,18 @@ Quick procedure (merge-only):
 
 ## Command Execution Architecture
 
-The command execution flow in Codex follows an event-driven pattern:
+The command execution flow in Code follows an event-driven pattern:
 
-1. **Core Layer** (`codex-core/src/codex.rs`):
+1. **Core Layer** (`code-rs/core/src/codex.rs`):
    - `on_exec_command_begin()` initiates command execution
    - Creates `EventMsg::ExecCommandBegin` events with command details
 
-2. **TUI Layer** (`codex-tui/src/chatwidget.rs`):
+2. **TUI Layer** (`code-rs/tui/src/chatwidget.rs`):
    - `handle_codex_event()` processes execution events
    - Manages `RunningCommand` state for active commands
    - Creates `HistoryCell::Exec` for UI rendering
 
-3. **History Cell** (`codex-tui/src/history_cell.rs`):
+3. **History Cell** (`code-rs/tui/src/history_cell.rs`):
    - `new_active_exec_command()` - Creates cell for running command
    - `new_completed_exec_command()` - Updates with final output
    - Handles syntax highlighting via `ParsedCommand`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 &ensp;
 
-**Every Code** (Code for short) is a fast, local coding agent for your terminal. It's a community-driven fork of `openai/codex` focused on real developer ergonomics: Browser integration, multi-agents, theming, and reasoning control — all while staying compatible with upstream.
+**Every Code** (Code for short) is a fast, local coding agent for your terminal. It owns its product direction, defaults, releases, and UX while preserving useful compatibility with Codex CLI and importing upstream improvements when they make the product better.
 
 &ensp;
 ## What's new
@@ -27,7 +27,7 @@
 
 
 - **Auto Review** – background ghost-commit watcher runs reviews in a separate worktree whenever a turn changes code; uses `codex-5.1-mini-high` and reports issues plus ready-to-apply fixes without blocking the main thread.
-- **Code Bridge** – Sentry-style local bridge that streams errors, console, screenshots, and control from running apps into Code; ships an MCP server; install by asking Code to pull `https://github.com/just-every/code-bridge`.
+- **Code Bridge** – Sentry-style local bridge that streams errors, console, screenshots, and control from running apps into Code; ships an MCP server.
 - **Plays well with Auto Drive** – reviews run in parallel with long Auto Drive tasks so quality checks land while the flow keeps moving.
 - **Quality-first focus** – the release shifts emphasis from "can the model write this file" to "did we verify it works".
 - _From v0.5.0:_ rename to Every Code, upgraded `/auto` planning/recovery, unified `/settings`, faster streaming/history with card-based activity, and more reliable `/resume` + `/undo`.
@@ -98,7 +98,7 @@ Note: If another tool already provides a `code` command (e.g. VS Code), our CLI 
 - **API key** (usage-based)
   - Set `export OPENAI_API_KEY=xyz` and run `code`
 
-### Install Claude & Gemini (optional)
+### Install External Agents (optional)
 
 Every Code supports orchestrating other AI CLI tools. Install these and config to use alongside Code.
 
@@ -293,7 +293,7 @@ model_reasoning_summary = "detailed"
 ## FAQ
 
 **How is this different from the original?**
-> This fork adds browser integration, multi-agent commands (`/plan`, `/solve`, `/code`), theme system, and enhanced reasoning controls while maintaining full compatibility.
+> Every Code is an independent product that keeps useful Codex CLI compatibility while owning its browser integration, multi-agent commands (`/plan`, `/solve`, `/code`), theme system, Auto Drive flows, and release defaults.
 
 **Can I use my existing Codex configuration?**
 > Yes. Every Code reads from both `~/.code/` (primary) and legacy `~/.codex/` directories. We only write to `~/.code/`, so Codex will keep running if you switch back; copy or remove legacy files if you notice conflicts.
@@ -307,13 +307,13 @@ model_reasoning_summary = "detailed"
 &ensp;
 ## Contributing
 
-We welcome contributions! Every Code maintains compatibility with upstream while adding community-requested features.
+We welcome contributions! Every Code accepts upstream improvements when they fit the product, but product direction, defaults, and release quality are decided here.
 
 ### Development workflow
 
 ```bash
 # Clone and setup
-git clone https://github.com/just-every/code.git
+git clone https://github.com/cbusillo/code.git
 cd code
 npm install
 
@@ -348,7 +348,7 @@ The `pre-push` hook runs `./pre-release.sh` automatically when pushing to `main`
 ## Legal & Use
 
 ### License & attribution
-- This project is a community fork of `openai/codex` under **Apache-2.0**. We preserve upstream LICENSE and NOTICE files.
+- This project descends from `openai/codex` under **Apache-2.0**. We preserve upstream LICENSE and NOTICE files.
 - **Every Code** (Code) is **not** affiliated with, sponsored by, or endorsed by OpenAI.
 
 ### Your responsibilities
@@ -370,8 +370,8 @@ AI providers can change eligibility, limits, models, or authentication flows. Ev
 
 Apache 2.0 - See [LICENSE](LICENSE) file for details.
 
-Every Code is a community fork of the original Codex CLI. We maintain compatibility while adding enhanced features requested by the developer community.
+Every Code is an independent coding agent descended from the original Codex CLI. We maintain compatibility where it helps users while developing Every Code's own product direction.
 
 &ensp;
 ---
-**Need help?** Open an issue on [GitHub](https://github.com/just-every/code/issues) or check our documentation.
+**Need help?** Open an issue on [GitHub](https://github.com/cbusillo/code/issues) or check our documentation.

--- a/code-rs/core/prompt_coder.md
+++ b/code-rs/core/prompt_coder.md
@@ -1,6 +1,6 @@
-In this environment, you are running as `code` and your name is Code. Code is a fork Codex CLI, an open source project led by OpenAI.
+In this environment, you are running as `code` and your name is Code. You are the Every Code CLI coding agent.
 
-Code is a fast, community-driven fork focused on key developer ergonomics: Browser control, multi-agent flows, autonomous tasks, and on-the-fly reasoning control - all while staying compatible with upstream.
+Every Code is a fast, community-driven coding agent focused on practical developer ergonomics: browser control, multi-agent flows, autonomous tasks, and on-the-fly reasoning control. It preserves compatibility with Codex CLI where useful, but Every Code owns its product direction, defaults, releases, and UX.
 
 # Changes
 

--- a/code-rs/core/src/model_family.rs
+++ b/code-rs/core/src/model_family.rs
@@ -22,7 +22,7 @@ const GPT_5_1_INSTRUCTIONS: &str = include_str!("../gpt_5_1_prompt.md");
 const GPT_5_2_INSTRUCTIONS: &str = include_str!("../gpt_5_2_prompt.md");
 const GPT_5_1_CODEX_MAX_INSTRUCTIONS: &str = include_str!("../gpt-5.1-codex-max_prompt.md");
 const GPT_5_2_CODEX_INSTRUCTIONS: &str = include_str!("../gpt-5.2-codex_prompt.md");
-const DEFAULT_PERSONALITY_HEADER: &str = "You are Codex, a coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals.";
+const DEFAULT_PERSONALITY_HEADER: &str = "You are Code, the Every Code coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals.";
 const LOCAL_FRIENDLY_TEMPLATE: &str =
     "You optimize for team morale and being a supportive teammate as much as code quality.";
 const LOCAL_PRAGMATIC_TEMPLATE: &str = "You are a deeply pragmatic, effective software engineer.";

--- a/code-rs/core/templates/model_instructions/gpt-5.2-codex_instructions_template.md
+++ b/code-rs/core/templates/model_instructions/gpt-5.2-codex_instructions_template.md
@@ -1,4 +1,4 @@
-You are Codex, a coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals.
+You are Code, the Every Code coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals.
 
 {{ personality }}
 

--- a/docs/local-overlay.md
+++ b/docs/local-overlay.md
@@ -1,19 +1,23 @@
-# Local Overlay
+# Upstream Import And Local Runtime Policy
 
-`local/cbusillo-overlay` is the canonical branch for the local `code` binary on
-this machine. It carries fork-specific behavior on top of `upstream/main`
-(`just-every/code`). Treat `codex-rs/` as a read-only mirror and put editable
-Rust changes under `code-rs/`.
+Every Code owns its product direction, defaults, releases, and UX. Until the
+default branch is renamed in #87, `local/cbusillo-overlay` remains the canonical
+branch for the local `code` binary on this machine. It imports useful upstream
+changes from `just-every/code` while keeping Every Code-specific behavior in the
+product branch.
+
+Treat `codex-rs/` as a read-only mirror of `openai/codex`; put editable Rust
+changes under `code-rs/`.
 
 Remote map:
 
-- `upstream`: `just-every/code`, the normal import source for overlay syncs.
-- `origin` / `fork`: `cbusillo/code`, where overlay branches and tags are
-  pushed.
+- `upstream`: `just-every/code`, the normal import source.
+- `origin` / `fork`: `cbusillo/code`, where Every Code branches and tags are
+  pushed until the repository identity transition finishes.
 - `openai`: reference remote for `openai/codex`; do not use it for routine
-  overlay imports or pushes.
+  imports or pushes.
 
-## Owned Differences
+## Every Code-Owned Surfaces
 
 - **Remote Inbox:** remote session control, request-user-input forwarding, and
   remote Auto Drive triggers. Keep transport/protocol code isolated from TUI
@@ -23,31 +27,31 @@ Remote map:
   consistent with `AGENTS.md`.
 - **Patch harness:** local validation for changed files, project tool discovery,
   and workspace-aware validator execution.
-- **Release workflow:** `overlay-v*` binary releases and local PATH rebuilds are
-  fork-owned infrastructure.
+- **Release workflow:** binary releases and local PATH rebuilds are Every Code
+  infrastructure. The `overlay-v*` tag format remains temporary until #87.
 - **Model defaults:** local defaults may intentionally differ from upstream, but
   request wire compatibility should use upstream model metadata when available.
 
 ## Upstream Sync
 
-Use the overlay helper from a clean `local/*` branch:
+Use the import helper from a clean `local/*` branch:
 
 ```sh
 just local-overlay-update
 ```
 
 After conflicts are resolved, preserve upstream fixes unless they contradict an
-owned overlay behavior above. During conflict resolution, prefer upstream unless
-the conflict touches one of those owned overlay areas. Keep
+Every Code-owned behavior above. During conflict resolution, prefer upstream
+unless the conflict touches one of those owned areas. Keep
 `scripts/local/overlay-picks.txt` empty unless a patch intentionally lives
-outside the overlay branch and must be replayed.
+outside the product branch and must be replayed.
 
 ## Release Cadence
 
-Cut a fork release after every successful upstream sync or local hotfix that
-should be installed elsewhere.
+Cut an Every Code release after every successful upstream import or local hotfix
+that should be installed elsewhere.
 
-Tag format:
+Temporary tag format, pending #87:
 
 ```text
 overlay-v<upstream-version>.<fork-patch>
@@ -55,8 +59,8 @@ overlay-v<upstream-version>.<fork-patch>
 
 Examples:
 
-- `overlay-v0.6.95.1` for the first fork release on upstream `0.6.95`
-- `overlay-v0.6.95.2` for a second local hotfix on the same upstream base
+- `overlay-v0.6.95.1` for the first Every Code release on upstream `0.6.95`
+- `overlay-v0.6.95.2` for a second Every Code hotfix on the same upstream base
 - `overlay-v0.6.96.1` after the next upstream version bump
 
 Required release gate:
@@ -95,7 +99,7 @@ cache buckets, and release dependency cache. It preserves
 Run without `--apply` to preview deletions. Use `--keep-current-fast-cache` or
 `--keep-release-cache` only when you intentionally want a warmer next build.
 
-Then push the overlay branch and tag to `origin`, and monitor `Binary Release`:
+Then push the product branch and tag to `origin`, and monitor `Binary Release`:
 
 ```sh
 git tag overlay-v0.6.96.1
@@ -103,7 +107,7 @@ git push origin local/cbusillo-overlay
 git push origin overlay-v0.6.96.1
 ```
 
-Do not push overlay releases to `upstream` or `openai`.
+Do not push Every Code releases to `upstream` or `openai`.
 
 ## Fork Health
 


### PR DESCRIPTION
## Summary
- Reframe README, AGENTS, repo metadata, and maintainer import docs around Every Code as the product identity
- Preserve upstream Codex / just-every/code language as provenance and import policy rather than lead identity
- Update owned runtime prompt identity surfaces to introduce Code as the Every Code CLI agent while leaving Codex model/wire slugs intact

## Prompt-file note
Two read-only agents audited the diff. One flagged Codex-compatible model prompt headers as a possible overreach; after checking runtime injection, I kept the Every Code header because it is the product identity text we send from our runtime, while Codex model names/slugs remain unchanged for compatibility.

## Validation
- `jq empty .github/github.json`
- `git diff --check`
- `./build-fast.sh`
- Changed-file JetBrains inspection was attempted; it reported 0 problems but timed out before a stable clean capture.

Refs #86
Parent #85