### PR TITLE
ci: use workspace-local release toolchain dirs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,9 @@ jobs:
     name: Preflight Tests (Linux fast E2E)
     runs-on: [self-hosted, Linux, X64, chris-testing]
     env:
-      CARGO_HOME: ${{ runner.temp }}/cargo-home
+      CARGO_HOME: ${{ github.workspace }}/.cargo-home
       CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
-      RUSTUP_HOME: ${{ runner.temp }}/rustup-home
+      RUSTUP_HOME: ${{ github.workspace }}/.rustup-home
     steps:
       - name: Prepare cargo target dir on data disk
         shell: bash
@@ -218,8 +218,8 @@ jobs:
     needs: [determine-version]
     runs-on: ${{ fromJson(matrix.runs_on) }}
     env:
-      CARGO_HOME: ${{ runner.temp }}/cargo-home
-      RUSTUP_HOME: ${{ runner.temp }}/rustup-home
+      CARGO_HOME: ${{ github.workspace }}/.cargo-home
+      RUSTUP_HOME: ${{ github.workspace }}/.rustup-home
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- replace job-level runner.temp references with github.workspace-local Cargo/rustup directories
- keeps release jobs isolated while avoiding workflow planning/expression failure that produced run 26352476057 with zero jobs

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
- git diff --check
- rg sweep for runner.temp and removed setup-python/sudo/shared-cargo patterns
- ./build-fast.sh

Refs #87