### PR TITLE
ci: build x86 musl release on hosted Ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,8 +224,8 @@ jobs:
       matrix:
         include:
           # Linux builds
-          - os: linux-self-hosted
-            runs_on: '["self-hosted","Linux","X64","chris-testing"]'
+          - os: ubuntu-24.04
+            runs_on: '["ubuntu-24.04"]'
             target: x86_64-unknown-linux-musl
             artifact: code-x86_64-unknown-linux-musl
           - os: ubuntu-24.04-arm


### PR DESCRIPTION
## Summary
- move the x86_64 musl release build from the passworded self-hosted runner to hosted ubuntu-24.04
- keep the target and artifact name unchanged so release packaging behavior stays the same

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'\n- git diff --check\n- ./build-fast.sh\n\nRefs #87