### PR TITLE
ci: run release preflight on hosted Ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
   preflight-tests:
     name: Preflight Tests (Linux fast E2E)
-    runs-on: [self-hosted, Linux, X64, chris-testing]
+    runs-on: ubuntu-24.04
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
       CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target


### PR DESCRIPTION
## Summary
- move the release preflight nextest gate from the self-hosted chris-testing runner to hosted ubuntu-24.04
- keep the publish job gated on `preflight-tests` through `needs`, preserving release validation coverage

## Why
Release run 26353066927 narrowed the remaining blocker to runner-specific nextest failures on the self-hosted Linux preflight runner. All release build matrix jobs passed after #107. Hosted Ubuntu gives this gate a standard CI environment with Chrome available and avoids the self-hosted stdio/sandbox mismatches currently tracked in #108.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'\n- git diff --check\n- ./build-fast.sh\n\nRefs #108\nRefs #87