### PR TITLE
test: check agent stdin without heredoc pipe

### DIFF
--- a/code-rs/core/src/agent_tool.rs
+++ b/code-rs/core/src/agent_tool.rs
@@ -3339,16 +3339,7 @@ mod tests {
     #[cfg(unix)]
     fn write_stdin_mode_script(path: &Path) {
         let script = r#"#!/bin/sh
-python3 - <<'PY'
-import os
-import stat
-
-mode = os.fstat(0).st_mode
-if stat.S_ISFIFO(mode):
-    print("fifo")
-else:
-    print("detached")
-PY
+python3 -c 'import os, stat; print("fifo" if stat.S_ISFIFO(os.fstat(0).st_mode) else "detached")'
 exit 0
 "#;
         std::fs::write(path, script).expect("write stdin mode script");


### PR DESCRIPTION
## Summary
- update the read-only agent stdin regression fixture to inspect fd 0 directly with `python3 -c`
- avoid the shell heredoc pipe that made the fixture report `fifo` on hosted Ubuntu even when the agent process stdin was detached

## Validation
- cargo test -p code-core agent_tool::tests::read_only_agents_redirect_stdin_away_from_parent_pipe
- ./build-fast.sh

Refs #108
Refs #87