### PR TITLE
chore(release): prepare v0.6.100

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.98",
+  "version": "0.6.100",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {
@@ -35,10 +35,10 @@
     "prettier": "^3.3.3"
   },
   "optionalDependencies": {
-    "@just-every/code-darwin-arm64": "0.6.98",
-    "@just-every/code-darwin-x64": "0.6.98",
-    "@just-every/code-linux-x64-musl": "0.6.98",
-    "@just-every/code-linux-arm64-musl": "0.6.98",
-    "@just-every/code-win32-x64": "0.6.98"
+    "@just-every/code-darwin-arm64": "0.6.100",
+    "@just-every/code-darwin-x64": "0.6.100",
+    "@just-every/code-linux-x64-musl": "0.6.100",
+    "@just-every/code-linux-arm64-musl": "0.6.100",
+    "@just-every/code-win32-x64": "0.6.100"
   }
 }


### PR DESCRIPTION
Automated release metadata branch from Release run 26355972159.

This branch currently contains the version-package update produced by the workflow. The workflow PR-creation permission fallback is being fixed separately so future runs can hand this off cleanly.

Refs #87
Refs #108