### PR TITLE
chore(release): prepare v0.6.100

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.98",
+  "version": "0.6.100",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {
@@ -35,10 +35,10 @@
     "prettier": "^3.3.3"
   },
   "optionalDependencies": {
-    "@just-every/code-darwin-arm64": "0.6.98",
-    "@just-every/code-darwin-x64": "0.6.98",
-    "@just-every/code-linux-x64-musl": "0.6.98",
-    "@just-every/code-linux-arm64-musl": "0.6.98",
-    "@just-every/code-win32-x64": "0.6.98"
+    "@just-every/code-darwin-arm64": "0.6.100",
+    "@just-every/code-darwin-x64": "0.6.100",
+    "@just-every/code-linux-x64-musl": "0.6.100",
+    "@just-every/code-linux-arm64-musl": "0.6.100",
+    "@just-every/code-win32-x64": "0.6.100"
   }
 }

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,24 +1,3 @@
-## @just-every/code v0.6.98
+## @just-every/code v0.6.100
 
-This release improves TUI workflows, thread handling, plugin sharing, and Linux portability across Code.
-
-### Changes
-
-- TUI: add upstream-compatible slash commands, a redesigned session picker, raw scrollback mode, and broader key/input polish.
-- Threads: return session IDs from thread and fork flows, paginate thread history, and keep live thread snapshots in sync.
-- Plugins: expand plugin sharing with access controls, discoverability settings, marketplace source filters, and richer plugin details.
-- Auth/Environments: enable AWS login credentials for Bedrock and route tools through selected environments more consistently.
-- Linux sandbox: bundle standalone `bwrap` builds and harden fallback/startup handling to improve reliability on Linux.
-
-### Install
-
-```bash
-npm install -g @just-every/code@latest
-code
-```
-
-### Thanks
-
-Thanks to @owenlin0, @alfozan111, and @vincentkoc for contributions!
-
-Compare: https://github.com/just-every/code/compare/v0.6.97...v0.6.98
+See CHANGELOG.md for details.


### PR DESCRIPTION
Automated release metadata branch from successful Release run 26356724247.

This PR contains the version/package metadata and fallback release notes for v0.6.100. Merge it to let the next protected `main` Release run create the tag, GitHub Release, Homebrew update, and npm packages from main.

Release run: https://github.com/cbusillo/code/actions/runs/26356724247

Refs #87
Refs #108