### PR TITLE
ci: make Homebrew tap publish best effort

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1070,7 +1070,12 @@ jobs:
           if ! git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
             git branch -M main || true
           fi
-          git push -u origin HEAD:main
+          if git push -u origin HEAD:main; then
+            echo "Published Homebrew formula update to just-every/homebrew-tap."
+          else
+            echo "::warning::Could not push Homebrew formula to just-every/homebrew-tap; check GH_PAT cross-repo write access."
+            exit 0
+          fi
 
       - name: Publish per-target npm binary packages (last)
         if: steps.version.outputs.skip_push == 'true' && steps.should_publish.outputs.publish == 'true'


### PR DESCRIPTION
## Summary
- make Homebrew tap publishing best-effort when the cross-repo token cannot push to just-every/homebrew-tap
- keep generating the formula, but warn and continue so GitHub Release/npm publishing is not blocked by tap credential configuration
- preserve a clear warning pointing at GH_PAT cross-repo write access

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'\n- git diff --check\n- ./build-fast.sh\n\nRefs #108\nRefs #87