### PR TITLE
fix: sort mixed release tags by version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -769,7 +769,7 @@ jobs:
 
           # Determine previous tag (the most recent tag before the new one).
           # If none exists, use the initial commit as the base.
-          PREV_TAG=$(git tag --sort=-v:refname | sed -n '2p' || true)
+          PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | sed -n '2p' || true)
           if [ -z "$PREV_TAG" ]; then
             BASE=$(git rev-list --max-parents=0 HEAD | tail -n1)
             RANGE="$BASE..HEAD"

--- a/scripts/local/fork-health.sh
+++ b/scripts/local/fork-health.sh
@@ -4,11 +4,15 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
+# shellcheck source=scripts/local/release-tag-utils.sh
+# shellcheck disable=SC1091
+source "$repo_root/scripts/local/release-tag-utils.sh"
+
 current_branch="$(git symbolic-ref --quiet --short HEAD || echo HEAD)"
 upstream_ref="${UPSTREAM_REF:-upstream/main}"
 product_branch="${PRODUCT_BRANCH:-$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')}"
 product_branch="${product_branch:-main}"
-latest_product_tag="$(git tag --list 'every-code-v*' 'overlay-v*' --sort=-v:refname | head -n 1 || true)"
+latest_product_tag="$(git tag --list 'every-code-v*' 'overlay-v*' | latest_release_tag || true)"
 latest_upstream_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1 || true)"
 package_version="$(node -p "require('$repo_root/codex-cli/package.json').version" 2>/dev/null || true)"
 

--- a/scripts/local/generate-overlay-release-notes.sh
+++ b/scripts/local/generate-overlay-release-notes.sh
@@ -15,23 +15,9 @@ Generates GitHub release notes for Every Code binary releases.
 USAGE
 }
 
-strip_release_tag_version() {
-  local release_tag="$1"
-  case "$release_tag" in
-    every-code-v*)
-      printf '%s\n' "${release_tag#every-code-v}"
-      ;;
-    overlay-v*)
-      printf '%s\n' "${release_tag#overlay-v}"
-      ;;
-    v*)
-      printf '%s\n' "${release_tag#v}"
-      ;;
-    *)
-      printf '%s\n' "$release_tag"
-      ;;
-  esac
-}
+# shellcheck source=release-tag-utils.sh
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/release-tag-utils.sh"
 
 tag=""
 code_version=""
@@ -83,10 +69,13 @@ if [[ -z "$tag" || -z "$code_version" || -z "$commit" || -z "$ref_name" || -z "$
   exit 2
 fi
 
-previous_tag="$(git tag --list 'every-code-v*' 'overlay-v*' \
-  --merged "$commit" --sort=-v:refname \
-  | grep -Fxv "$tag" \
-  | head -n 1 || true)"
+previous_tag="$(
+  git tag --list 'every-code-v*' 'overlay-v*' \
+    --merged "$commit" \
+    | grep -Fxv -- "$tag" \
+    | latest_release_tag \
+    || true
+)"
 
 if [[ -n "$previous_tag" ]]; then
   range_base="$previous_tag"

--- a/scripts/local/release-tag-utils.sh
+++ b/scripts/local/release-tag-utils.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+release_tag_version() {
+  local release_tag="$1"
+  case "$release_tag" in
+    every-code-v*)
+      printf '%s\n' "${release_tag#every-code-v}"
+      ;;
+    overlay-v*)
+      printf '%s\n' "${release_tag#overlay-v}"
+      ;;
+    v*)
+      printf '%s\n' "${release_tag#v}"
+      ;;
+    *)
+      printf '%s\n' "$release_tag"
+      ;;
+  esac
+}
+
+strip_release_tag_version() {
+  release_tag_version "$1"
+}
+
+release_tag_priority() {
+  local release_tag="$1"
+  case "$release_tag" in
+    every-code-v*)
+      printf '2\n'
+      ;;
+    overlay-v* | v*)
+      printf '1\n'
+      ;;
+    *)
+      printf '0\n'
+      ;;
+  esac
+}
+
+release_tag_sort_key() {
+  local release_tag="$1"
+  printf '%s\t%s\t%s\n' \
+    "$(release_tag_version "$release_tag")" \
+    "$(release_tag_priority "$release_tag")" \
+    "$release_tag"
+}
+
+latest_release_tag() {
+  while IFS= read -r release_tag; do
+    [[ -n "$release_tag" ]] || continue
+    release_tag_sort_key "$release_tag"
+  done \
+    | sort -t $'\t' -k1,1V -k2,2n -k3,3r \
+    | tail -n 1 \
+    | sed -n 's/^[^\t]*\t[^\t]*\t//p'
+}
+


### PR DESCRIPTION
## Summary
- add a shared local release-tag helper that normalizes `every-code-v*`, `overlay-v*`, and `v*` versions before sorting
- use version-aware tag ordering for legacy Every Code release notes and fork health output
- constrain the current Release workflow previous-tag lookup to plain `v*` release tags

## Validation
- shellcheck scripts/local/release-tag-utils.sh scripts/local/generate-overlay-release-notes.sh scripts/local/fork-health.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'\n- git diff --check\n- bash -n scripts/local/release-tag-utils.sh scripts/local/generate-overlay-release-notes.sh scripts/local/fork-health.sh\n- ./scripts/local/fork-health.sh | sed -n '1,14p'\n- ./build-fast.sh