### PR TITLE
chore(release): prepare v0.6.101

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.100",
+  "version": "0.6.101",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-## @just-every/code v0.6.100
+## @just-every/code v0.6.101
 
 See CHANGELOG.md for details.


### PR DESCRIPTION
This release metadata PR was prepared by Release run 26370095181 after #132. Merging it lets the protected main-branch Release workflow create tag v0.6.101, publish GitHub Release assets, and attach update-manifest.json.