### PR TITLE
Fix Windows release build for update check

### DIFF
--- a/code-rs/cli/src/update.rs
+++ b/code-rs/cli/src/update.rs
@@ -214,6 +214,7 @@ fn http_client(user_agent: &str) -> anyhow::Result<reqwest::Client> {
         .build()?)
 }
 
+#[cfg(target_family = "unix")]
 async fn install_direct_binary(asset: &PlatformAsset, exe: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 


### PR DESCRIPTION
## Summary
- compile the direct self-update installer only on Unix so Windows release builds keep the guarded refusal path

## Validation
- `cargo test -p code-cli update::tests`
- `./build-fast.sh`

Follow-up to #135 after the Release workflow Windows build failed on `std::os::unix`.