### PR TITLE
chore(release): prepare v0.6.102

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.101",
+  "version": "0.6.102",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-## @just-every/code v0.6.101
+## @just-every/code v0.6.102
 
 See CHANGELOG.md for details.


### PR DESCRIPTION
This automated release PR contains the version and release-notes changes for v0.6.102. Merge this PR to let the protected main-branch Release workflow create the tag and GitHub Release assets from main.