### PR TITLE
Keep local release binary out of fast builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Examples:
 
 - `main` is the Every Code product branch and the GitHub default branch.
 - Use `just local-code-rebuild` to rebuild the current branch into the PATH-resolved binary.
-- After `./build-fast.sh`, run `just local-code-rebuild` again before release smoke checks; the fast build can leave the PATH-resolved `code` pointing at a dev-fast binary that reports `0.0.0`.
+- After `./build-fast.sh`, run `just local-code-rebuild` again before release smoke checks; the fast build validates dev-fast artifacts, while the rebuild recipe owns the PATH-resolved release binary and embeds the package version.
 - Before leaving a local work session, run `just local-cleanup-space --apply`
   to remove rebuildable target/cache artifacts while preserving
   `code-rs/target/release/code`.

--- a/build-fast.sh
+++ b/build-fast.sh
@@ -723,11 +723,13 @@ if [ $? -eq 0 ]; then
       fi
     fi
 
-    mkdir -p ./target/release
-    if [ -e "./target/release/${CRATE_PREFIX}" ]; then
-        rm -f "./target/release/${CRATE_PREFIX}"
+    if [ "$PROFILE" = "release" ] || [ "$PROFILE" = "release-prod" ]; then
+      mkdir -p ./target/release
+      if [ -e "./target/release/${CRATE_PREFIX}" ]; then
+          rm -f "./target/release/${CRATE_PREFIX}"
+      fi
+      ln -sf "${release_link_target}" "./target/release/${CRATE_PREFIX}"
     fi
-    ln -sf "${release_link_target}" "./target/release/${CRATE_PREFIX}"
 
     # Update the symlinks in CLI wrapper directories
     if [ -d "../codex-cli/bin" ]; then

--- a/docs/local-overlay.md
+++ b/docs/local-overlay.md
@@ -76,8 +76,15 @@ code exec -m gpt-5.5 --sandbox read-only --max-seconds 30 "Reply with exactly OK
 ```
 
 Run `just local-code-rebuild` after any release-readiness `./build-fast.sh` run:
-the fast build can leave the PATH-resolved `code` pointing at a dev-fast binary
-that reports `0.0.0`.
+the fast build creates dev-fast artifacts for validation, while the rebuild
+recipe owns the PATH-resolved release binary and embeds the package version.
+
+If an old manual Homebrew link exists, remove it so PATH resolution stays
+repo-owned and predictable:
+
+```sh
+just local-remove-homebrew-code-link
+```
 
 ## Session Exit Cleanup
 

--- a/justfile
+++ b/justfile
@@ -68,6 +68,10 @@ local-code-rebuild:
     ./scripts/local/rebuild-path-code.sh
 
 [no-cd]
+local-remove-homebrew-code-link:
+    ./scripts/local/remove-homebrew-code-link.sh
+
+[no-cd]
 local-upstream-import:
     ./scripts/local/update-overlay-from-upstream.sh
 

--- a/scripts/local/rebuild-path-code.sh
+++ b/scripts/local/rebuild-path-code.sh
@@ -12,6 +12,10 @@ resolve_code_version() {
 code_version="${CODE_VERSION:-$(resolve_code_version || true)}"
 
 echo "Building release binary from $code_rs_root"
+if [[ -L "$release_bin" ]]; then
+	echo "Replacing release-bin symlink with a real binary: $release_bin"
+	rm -f "$release_bin"
+fi
 if [[ -n "$code_version" ]]; then
 	echo "Embedding CODE_VERSION=$code_version"
 	CODE_VERSION="$code_version" cargo build --manifest-path "$code_rs_root/Cargo.toml" -p code-cli --release

--- a/scripts/local/remove-homebrew-code-link.sh
+++ b/scripts/local/remove-homebrew-code-link.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+homebrew_link="/opt/homebrew/bin/code"
+repo_release_bin="$repo_root/code-rs/target/release/code"
+
+if [[ ! -L "$homebrew_link" ]]; then
+	echo "No Homebrew code symlink to remove: $homebrew_link"
+	exit 0
+fi
+
+link_target="$(readlink "$homebrew_link")"
+if [[ "$link_target" != "$repo_release_bin" ]]; then
+	echo "Refusing to remove $homebrew_link; it points to $link_target" >&2
+	exit 1
+fi
+
+rm -f "$homebrew_link"
+echo "Removed stale Homebrew code symlink: $homebrew_link"


### PR DESCRIPTION
## Summary
- stop dev-fast builds from rewriting `code-rs/target/release/code`
- make `just local-code-rebuild` replace a stale release-bin symlink with a real release binary
- add an explicit helper to remove the old manual `/opt/homebrew/bin/code` symlink
- document the local binary ownership flow

## Validation
- `just local-code-rebuild`
- `./build-fast.sh`
- `code --version` reports `code 0.6.102` after both commands
- `code update-check --tag v0.6.102` reports `status: up to date`
- removed local stale `/opt/homebrew/bin/code` symlink via `just local-remove-homebrew-code-link`