### PR TITLE
Handle local rebuild script edge cases

### DIFF
--- a/scripts/local/rebuild-path-code.sh
+++ b/scripts/local/rebuild-path-code.sh
@@ -11,8 +11,21 @@ resolve_code_version() {
 
 code_version="${CODE_VERSION:-$(resolve_code_version || true)}"
 
+removed_release_symlink_target=""
+restore_release_symlink_on_error() {
+	local exit_code="$?"
+	if [[ "$exit_code" -ne 0 && -n "$removed_release_symlink_target" && ! -e "$release_bin" && ! -L "$release_bin" ]]; then
+		mkdir -p "$(dirname "$release_bin")"
+		ln -s "$removed_release_symlink_target" "$release_bin"
+		echo "Restored release-bin symlink after failed rebuild: $release_bin -> $removed_release_symlink_target" >&2
+	fi
+	exit "$exit_code"
+}
+
 echo "Building release binary from $code_rs_root"
 if [[ -L "$release_bin" ]]; then
+	removed_release_symlink_target="$(readlink "$release_bin")"
+	trap restore_release_symlink_on_error EXIT
 	echo "Replacing release-bin symlink with a real binary: $release_bin"
 	rm -f "$release_bin"
 fi
@@ -23,6 +36,7 @@ else
 	echo "warning: could not resolve CODE_VERSION from rust-v tags; building without override" >&2
 	cargo build --manifest-path "$code_rs_root/Cargo.toml" -p code-cli --release
 fi
+trap - EXIT
 
 path_code="$(command -v code || true)"
 if [[ -z "$path_code" ]]; then

--- a/scripts/local/remove-homebrew-code-link.sh
+++ b/scripts/local/remove-homebrew-code-link.sh
@@ -2,19 +2,29 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-homebrew_link="/opt/homebrew/bin/code"
 repo_release_bin="$repo_root/code-rs/target/release/code"
+homebrew_links=(
+	"/opt/homebrew/bin/code"
+	"/usr/local/bin/code"
+)
 
-if [[ ! -L "$homebrew_link" ]]; then
-	echo "No Homebrew code symlink to remove: $homebrew_link"
-	exit 0
+removed=0
+for homebrew_link in "${homebrew_links[@]}"; do
+	if [[ ! -L "$homebrew_link" ]]; then
+		continue
+	fi
+
+	link_target="$(readlink "$homebrew_link")"
+	if [[ "$link_target" != "$repo_release_bin" ]]; then
+		echo "Skipping unrelated Homebrew code symlink: $homebrew_link -> $link_target"
+		continue
+	fi
+
+	rm -f "$homebrew_link"
+	removed=1
+	echo "Removed stale Homebrew code symlink: $homebrew_link"
+done
+
+if [[ "$removed" -eq 0 ]]; then
+	echo "No repo-owned Homebrew code symlinks found."
 fi
-
-link_target="$(readlink "$homebrew_link")"
-if [[ "$link_target" != "$repo_release_bin" ]]; then
-	echo "Refusing to remove $homebrew_link; it points to $link_target" >&2
-	exit 1
-fi
-
-rm -f "$homebrew_link"
-echo "Removed stale Homebrew code symlink: $homebrew_link"


### PR DESCRIPTION
## Summary
- restore the prior release-bin symlink if `local-code-rebuild` fails after removing it
- make Homebrew cleanup scan both common prefixes and skip unrelated `code` links instead of aborting

## Validation
- `just local-remove-homebrew-code-link`
- simulated failed rebuild restores the previous release symlink
- `./build-fast.sh`