### PR TITLE
chore(release): prepare v0.6.106

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.105",
+  "version": "0.6.106",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-## @just-every/code v0.6.105
+## @just-every/code v0.6.106
 
 See CHANGELOG.md for details.


### PR DESCRIPTION
Automated release metadata branch from Release run 26428878164.

Merging this lets the protected main-branch Release workflow create tag v0.6.106 and publish GitHub Release assets from main.