### PR TITLE
Fix retired model test expectations

### DIFF
--- a/code-rs/core/src/config.rs
+++ b/code-rs/core/src/config.rs
@@ -3834,30 +3834,6 @@ context_mode = "1m"
     }
 
     #[test]
-    fn context_mode_one_m_is_inert_for_unsupported_models() -> anyhow::Result<()> {
-        let code_home = TempDir::new()?;
-        let cfg = toml::from_str::<ConfigToml>(
-            r#"
-model = "gpt-5.4"
-context_mode = "1m"
-"#,
-        )?;
-        let config = Config::load_from_base_config_with_overrides(
-            cfg,
-            ConfigOverrides {
-                cwd: Some(code_home.path().to_path_buf()),
-                ..Default::default()
-            },
-            code_home.path().to_path_buf(),
-        )?;
-
-        assert_eq!(config.context_mode, Some(ContextMode::OneM));
-        assert_eq!(config.model_context_window, Some(272_000));
-        assert_eq!(config.model_auto_compact_token_limit, Some(244_800));
-        Ok(())
-    }
-
-    #[test]
     fn context_mode_auto_preserves_gpt_5_5_manifest_limits() -> anyhow::Result<()> {
         let code_home = TempDir::new()?;
         let cfg = toml::from_str::<ConfigToml>(
@@ -3882,7 +3858,7 @@ context_mode = "auto"
     }
 
     #[test]
-    fn context_mode_one_m_is_inert_for_gpt_5_5() -> anyhow::Result<()> {
+    fn context_mode_one_m_is_inert_for_unsupported_models() -> anyhow::Result<()> {
         let code_home = TempDir::new()?;
         let cfg = toml::from_str::<ConfigToml>(
             r#"

--- a/code-rs/tui/src/bottom_pane/model_selection_view.rs
+++ b/code-rs/tui/src/bottom_pane/model_selection_view.rs
@@ -1329,12 +1329,11 @@ mod tests {
 
         let lines = buffer_body_lines(&buf, width, height);
         let visible = lines.join("\n");
-        let has_header = visible.contains("GPT-5.3-Codex");
-        let has_desc = visible.contains("Frontier agentic coding")
-            && visible.contains("25% faster than previous models.");
+        let has_header = visible.contains("GPT-5.5");
+        let has_desc = visible.contains("Frontier model for complex coding");
 
-        assert!(has_header);
-        assert!(has_desc);
+        assert!(has_header, "expected header in rendered model picker:\n{visible}");
+        assert!(has_desc, "expected description in rendered model picker:\n{visible}");
     }
 
     #[test]
@@ -1607,7 +1606,7 @@ mod tests {
     }
 
     #[test]
-    fn model_selection_shows_unavailable_context_hint_for_unsupported_model() {
+    fn model_selection_shows_available_context_hint_for_supported_model() {
         let presets = vec![make_preset("gpt-5.4")];
         let (tx, _rx) = mpsc::channel::<AppEvent>();
         let view = ModelSelectionView::new(
@@ -1638,13 +1637,10 @@ mod tests {
 
         let lines = buffer_body_lines(&buf, width, height);
         assert!(
-            lines.iter().any(|line| line.contains("1M Context: unavailable")),
-            "expected unsupported model to show unavailable context, got:\n{}",
+            lines.iter().any(|line| line.contains("1M Context: auto")),
+            "expected supported model to show auto context, got:\n{}",
             lines.join("\n")
         );
-        assert!(lines.iter().any(|line| {
-            line.contains("Unavailable for this model. Saved settings apply automatically on supported models.")
-        }));
     }
 
     #[test]

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -32845,7 +32845,7 @@ use code_core::protocol::OrderMeta;
         chat.handle_model_command("gpt-5.4".to_string());
 
         assert_eq!(chat.config.model, "gpt-5.4");
-        assert_eq!(chat.config.model_reasoning_effort, ReasoningEffort::Medium);
+        assert_eq!(chat.config.model_reasoning_effort, ReasoningEffort::XHigh);
     }
 
     #[test]

--- a/code-rs/tui/src/chatwidget/agent_summary.rs
+++ b/code-rs/tui/src/chatwidget/agent_summary.rs
@@ -60,7 +60,7 @@ mod agent_summary_counts_tests {
     #[test]
     fn missing_builtins_default_to_disabled() {
         let agents = vec![
-            make_agent("code-gpt-5.2-codex", true),
+            make_agent("code-gpt-5.5", true),
             make_agent("code-gpt-5.4", true),
         ];
 
@@ -74,7 +74,7 @@ mod agent_summary_counts_tests {
     #[test]
     fn custom_agents_are_counted() {
         let agents = vec![
-            make_agent("code-gpt-5.3-codex", true),
+            make_agent("code-gpt-5.5", true),
             make_agent("my-custom-agent", false),
         ];
 


### PR DESCRIPTION
## Summary
- replace retired 5.2/5.3 Codex test fixtures with supported 5.5/5.4 fixtures
- update model picker expectations for the current GPT-5.5 and GPT-5.4 context behavior
- rename the unsupported 1M context test to cover GPT-5.5 instead of GPT-5.4

## Validation
- cd code-rs && cargo test -p code-core context_mode_one_m_is_inert_for_unsupported_models -- --nocapture
- cd code-rs && cargo test -p code-tui model_selection_keeps_model_header_visible_for_first_entry -- --nocapture
- cd code-rs && cargo test -p code-tui model_selection_shows_available_context_hint_for_supported_model -- --nocapture
- cd code-rs && cargo test -p code-tui missing_builtins_default_to_disabled -- --nocapture
- cd code-rs && cargo test -p code-tui custom_agents_are_counted -- --nocapture
- cd code-rs && cargo test -p code-tui model_command_accepts_supported_non_curated_remote_model -- --nocapture
- ./build-fast.sh