### PR TITLE
Remove stale npx workflow caches

### DIFF
--- a/.github/workflows/issue-code.yml
+++ b/.github/workflows/issue-code.yml
@@ -99,15 +99,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Cache npm (npx) downloads
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-          key: npm-cache-${{ runner.os }}-node20-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock') }}
-          restore-keys: |
-            npm-cache-${{ runner.os }}-node20-
-
       - name: Cache ripgrep binary
         uses: actions/cache@v4
         with:

--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -357,16 +357,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Cache npm (npx) downloads
-        if: steps.check_upstream.outputs.skip != 'true'
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-          key: npm-cache-${{ runner.os }}-node20-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock') }}
-          restore-keys: |
-            npm-cache-${{ runner.os }}-node20-
-
       - name: Start local OpenAI proxy (no key to agent; verbose logging)
         if: steps.check_upstream.outputs.skip != 'true'
         id: openai_proxy


### PR DESCRIPTION
## Summary
- remove obsolete npm/npx cache steps from issue-code and upstream-merge workflows
- keep Node setup because both workflows still run the local OpenAI proxy with node
- continue using the repo-built CODE_BIN path for agent execution

## Validation
- git diff --check
- rg -n "Cache npm \\(npx\\)|npx -y @just-every/code@latest|@just-every/code@latest" .github/workflows/issue-code.yml .github/workflows/upstream-merge.yml .github/workflows/issue-comment.yml (no matches)
- ./build-fast.sh

Refs #130