### PR TITLE
Normalize code exec harness output root

### DIFF
--- a/tools/code-exec-harness/harness.py
+++ b/tools/code-exec-harness/harness.py
@@ -853,7 +853,7 @@ def assert_expectations(summary: dict[str, Any], scenario: dict[str, Any]) -> li
 def run_scenario(path: Path, args: argparse.Namespace) -> int:
     scenario = load_json(path)
     name = scenario_name(path, scenario)
-    paths = make_paths(Path(args.output_root), name)
+    paths = make_paths(resolve_path(str(args.output_root), Path.cwd()), name)
     scenario_dir = path.parent.resolve()
     extra_roots = [resolve_path(value, Path.cwd()) for value in args.skill_root]
 


### PR DESCRIPTION
## Summary

- resolve `--output-root` to an absolute path before creating harness run directories
- keeps generated `code exec -C` workspace paths stable even when callers pass a relative output root

## Validation

- `python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/manual-skill-not-implicit.json --output-root .tmp/harness-relative-root-check --dry-run`
- `python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/manual-skill-not-implicit.json --output-root .tmp/harness-relative-root-check`

Closes #158
