### PR TITLE
Update Rust workspace install guidance

### DIFF
--- a/code-rs/README.md
+++ b/code-rs/README.md
@@ -1,45 +1,56 @@
-# Codex CLI (Rust Implementation)
+# Every Code CLI (Rust Implementation)
 
-We provide Codex CLI as a standalone, native executable to ensure a zero-dependency install.
+Every Code provides a standalone native `code` executable. This directory is the
+Rust workspace that builds the product CLI used for local dogfooding and GitHub
+Release updates.
 
-## Installing Codex
+## Installing Every Code
 
-Today, the easiest way to install Codex is via `npm`:
+The canonical internal install and update source is the repository's GitHub
+Releases, including the generated `update-manifest.json` consumed by the CLI
+updater. npm and Homebrew publishing are deferred unless package-manager
+distribution becomes intentional again.
 
 ```shell
-npm i -g @openai/codex
-codex
+code update-check
+code update --yes
 ```
 
-You can also install via Homebrew (`brew install codex`) or download a platform-specific release directly from our [GitHub Releases](https://github.com/openai/codex/releases).
+For local development, build from the repository root with:
+
+```shell
+./build-fast.sh
+```
 
 ## What's new in the Rust CLI
 
-The Rust implementation is now the maintained Codex CLI and serves as the default experience. It includes a number of features that the legacy TypeScript CLI never supported.
+The Rust implementation is the maintained Every Code CLI and serves as the
+default experience. It includes a number of features that the legacy TypeScript
+CLI never supported.
 
 ### Config
 
-Codex supports a rich set of configuration options. Note that the Rust CLI uses `config.toml` instead of `config.json`. See [`docs/config.md`](../docs/config.md) for details.
+Code supports a rich set of configuration options. Note that the Rust CLI uses `config.toml` instead of `config.json`. See [`docs/config.md`](../docs/config.md) for details.
 
 ### Model Context Protocol Support
 
-Codex CLI functions as an MCP client that can connect to MCP servers on startup. See the [`mcp_servers`](../docs/config.md#mcp_servers) section in the configuration documentation for details.
+Code CLI functions as an MCP client that can connect to MCP servers on startup. See the [`mcp_servers`](../docs/config.md#mcp_servers) section in the configuration documentation for details.
 
-It is still experimental, but you can also launch Codex as an MCP _server_ by running `codex mcp-server`. Use the [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector) to try it out:
+It is still experimental, but you can also launch Code as an MCP _server_ by running `code mcp-server`. Use the [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector) to try it out:
 
 ```shell
-npx @modelcontextprotocol/inspector codex mcp-server
+npx @modelcontextprotocol/inspector code mcp-server
 ```
 
-Use `codex mcp` to add/list/get/remove MCP server launchers defined in `config.toml`, and `codex mcp-server` to run the MCP server directly.
+Use `code mcp` to add/list/get/remove MCP server launchers defined in `config.toml`, and `code mcp-server` to run the MCP server directly.
 
 ### Notifications
 
 You can enable notifications by configuring a script that is run whenever the agent finishes a turn. The [notify documentation](../docs/config.md#notify) includes a detailed example that explains how to get desktop notifications via [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS.
 
-### `codex exec` to run Codex programmatically/non-interactively
+### `code exec` to run Code programmatically/non-interactively
 
-To run Codex non-interactively, run `codex exec PROMPT` (you can also pass the prompt via `stdin`) and Codex will work on your task until it decides that it is done and exits. Output is printed to the terminal directly. You can set the `RUST_LOG` environment variable to see more about what's going on.
+To run Code non-interactively, run `code exec PROMPT` (you can also pass the prompt via `stdin`) and Code will work on your task until it decides that it is done and exits. Output is printed to the terminal directly. You can set the `RUST_LOG` environment variable to see more about what's going on.
 
 ### Use `@` for file search
 
@@ -47,13 +58,13 @@ Typing `@` triggers a fuzzy-filename search over the workspace root. Use up/down
 
 ### Esc–Esc to edit a previous message
 
-When the chat composer is empty, press Esc to prime “backtrack” mode. Press Esc again to open a transcript preview highlighting the last user message; press Esc repeatedly to step to older user messages. Press Enter to confirm and Codex will fork the conversation from that point, trim the visible transcript accordingly, and pre‑fill the composer with the selected user message so you can edit and resubmit it.
+When the chat composer is empty, press Esc to prime “backtrack” mode. Press Esc again to open a transcript preview highlighting the last user message; press Esc repeatedly to step to older user messages. Press Enter to confirm and Code will fork the conversation from that point, trim the visible transcript accordingly, and pre‑fill the composer with the selected user message so you can edit and resubmit it.
 
 In the transcript preview, the footer shows an `Esc edit prev` hint while editing is active.
 
 ### `--cd`/`-C` flag
 
-Sometimes it is not convenient to `cd` to the directory you want Codex to use as the "working root" before running Codex. Fortunately, `codex` supports a `--cd` option so you can specify whatever folder you want. You can confirm that Codex is honoring `--cd` by double-checking the **workdir** it reports in the TUI at the start of a new session.
+Sometimes it is not convenient to `cd` to the directory you want Code to use as the "working root" before running Code. Fortunately, `code` supports a `--cd` option so you can specify whatever folder you want. You can confirm that Code is honoring `--cd` by double-checking the **workdir** it reports in the TUI at the start of a new session.
 
 ### Shell completions
 
@@ -65,16 +76,16 @@ code completion zsh
 code completion fish
 ```
 
-### Experimenting with the Codex Sandbox
+### Experimenting with the Code Sandbox
 
-To test to see what happens when a command is run under the sandbox provided by Codex, we provide the following subcommands in Codex CLI:
+To test to see what happens when a command is run under the sandbox provided by Code, we provide the following subcommands in Code CLI:
 
 ```
 # macOS
-codex debug seatbelt [--full-auto] [COMMAND]...
+code debug seatbelt [--full-auto] [COMMAND]...
 
 # Linux
-codex debug landlock [--full-auto] [COMMAND]...
+code debug landlock [--full-auto] [COMMAND]...
 ```
 
 ### Selecting a sandbox policy via `--sandbox`
@@ -82,14 +93,14 @@ codex debug landlock [--full-auto] [COMMAND]...
 The Rust CLI exposes a dedicated `--sandbox` (`-s`) flag that lets you pick the sandbox policy **without** having to reach for the generic `-c/--config` option:
 
 ```shell
-# Run Codex with the default, read-only sandbox
-codex --sandbox read-only
+# Run Code with the default, read-only sandbox
+code --sandbox read-only
 
 # Allow the agent to write within the current workspace while still blocking network access
-codex --sandbox workspace-write
+code --sandbox workspace-write
 
 # Danger! Disable sandboxing entirely (only do this if you are already running in a container or other isolated env)
-codex --sandbox danger-full-access
+code --sandbox danger-full-access
 ```
 
 The same setting can be persisted in `~/.code/config.toml` via the top-level `sandbox_mode = "MODE"` key (Code will also read legacy `~/.codex/config.toml`), e.g. `sandbox_mode = "workspace-write"`.
@@ -105,7 +116,7 @@ allow_git_writes = false   # default is true; set false to protect .git
 
 ### TUI anti-truncation fallback
 
-If the transcript's last line intermittently clips, Codex keeps a guarded
+If the transcript's last line intermittently clips, Code keeps a guarded
 bottom spacer enabled. The TUI adds a 1–2 row overscan pad when the computed
 history height looks like it might land flush with the viewport, reducing the
 chance the final row disappears mid-stream. Enable `RUST_LOG=debug` to log when
@@ -131,7 +142,7 @@ Use these console helpers to diagnose motion/cancellation behavior when testing 
 
 This folder is the root of a Cargo workspace. It contains quite a bit of experimental code, but here are the key crates:
 
-- [`core/`](./core) contains the business logic for Codex. Ultimately, we hope this to be a library crate that is generally useful for building other Rust/native applications that use Codex.
+- [`core/`](./core) contains the business logic for Code. Ultimately, we hope this to be a library crate that is generally useful for building other Rust/native applications that use Code.
 - [`exec/`](./exec) "headless" CLI for use in automation.
 - [`tui/`](./tui) CLI that launches a fullscreen TUI built with [Ratatui](https://ratatui.rs/).
 - [`cli/`](./cli) CLI multitool that provides the aforementioned CLIs via subcommands.


### PR DESCRIPTION
## Summary
- replace stale upstream Codex npm/Homebrew install guidance in code-rs/README.md
- document GitHub Releases and the update manifest as the current internal update source
- align examples and command names with Every Code's [?2004h[?1007h[?1004h[?1049h CLI while preserving the legacy config-path note

## Validation
- git diff --check
- rg -n "@openai/codex|brew install codex|openai/codex/releases|Installing Codex|Codex CLI|\bcodex\b" code-rs/README.md (only legacy config-path note remains)
- ./build-fast.sh

Refs #130