### PR TITLE
Move release preflight target to data disk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ -d /mnt ] && [ -w /mnt ]; then
+            CARGO_TARGET_DIR="/mnt/code-release-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> "$GITHUB_ENV"
+          fi
+          echo "CI_CLI_BIN=$CARGO_TARGET_DIR/dev-fast/code" >> "$GITHUB_ENV"
           mkdir -p "$CARGO_TARGET_DIR"
+          df -h "$CARGO_TARGET_DIR"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,7 +92,6 @@ jobs:
         shell: bash
         env:
           SKIP_CARGO_TESTS: "1"
-          CI_CLI_BIN: ${{ env.CARGO_TARGET_DIR }}/dev-fast/code
         run: bash scripts/ci-tests.sh
 
       - name: Drop dev-fast artifacts before workspace tests


### PR DESCRIPTION
## Summary
- make the Release preflight job use /mnt for CARGO_TARGET_DIR when available
- export CI_CLI_BIN from the resolved cargo target directory so smoke tests use the moved dev-fast binary
- keep the existing workspace target path as a fallback when /mnt is unavailable

## Why
The #162 Release run failed in Linux nextest with rustc reporting "No space left on device" while compiling code-tui. The job step was named as using the data disk, but CARGO_TARGET_DIR still pointed inside the workspace filesystem.

## Validation
- git diff --check
- ./build-fast.sh