### PR TITLE
Update CLI issue template guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-cli.yml
+++ b/.github/ISSUE_TEMPLATE/3-cli.yml
@@ -1,5 +1,5 @@
 name: 💻 CLI Bug
-description: Report an issue in the Codex CLI
+description: Report an issue in the Every Code CLI
 labels:
   - bug
 body:
@@ -10,7 +10,7 @@ body:
 
         If you need help or support using Code, and are not reporting a bug, please post on [code/discussions](https://github.com/just-every/code/discussions), where you can ask questions or engage with others on ideas for how to improve Code.
 
-        Make sure you are running the [latest](https://npmjs.com/package/@just-every/code) version of the Code CLI. The bug you are experiencing may already have been fixed.
+        Run `code update-check` to make sure you are using the latest GitHub Release build. The bug you are experiencing may already have been fixed.
 
   - type: input
     id: version


### PR DESCRIPTION
## Summary
- rename the CLI bug template description from Codex CLI to Every Code CLI
- replace the stale npm latest link with current version: 0.6.106
latest version:  v0.6.106
channel:         stable
published at:    2026-05-26T03:34:10Z
commit:          9ac61b3ff2f85a34947b9ad36ae95e98e3c939a4
target:          aarch64-apple-darwin
asset:           code-aarch64-apple-darwin.tar.gz
url:             https://github.com/cbusillo/code/releases/download/v0.6.106/code-aarch64-apple-darwin.tar.gz
sha256:          8bdcb5ce861ca3ef59ea25964c80d3420b6dced49d8f9eb0afebacc9574afb49
size:            21271957 bytes
status:          up to date / GitHub Release guidance

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/3-cli.yml"); puts "yaml ok"'
- rg -n "Codex CLI|npmjs.com/package/@just-every/code|@just-every/code\) version" .github/ISSUE_TEMPLATE/3-cli.yml (no matches)
- ./build-fast.sh

Refs #130