### PR TITLE
Clarify agent model selectors

### DIFF
--- a/code-rs/core/prompt_coder.md
+++ b/code-rs/core/prompt_coder.md
@@ -60,14 +60,14 @@ agent {
     "task": "Implement JWT middleware (RS256) with key rotation and unit/integration tests. Preserve existing OAuth flows. Provide README usage snippet.",
     "context": "Service: services/api (Rust Axum). Secrets via env. CI: `cargo test --all`.",
     "files": ["services/api", "services/api/src", "services/api/Cargo.toml"],
-    "models": ["code-gpt-5.4","claude-sonnet-4.6","antigravity"], // Agent/model selectors; antigravity launches agy and uses Antigravity's configured model.
+    "models": ["code-gpt-5.4","claude-sonnet-4.6","antigravity"], // Agent/model selector slugs; external CLI selectors use that tool's configured model.
     "output": "Middleware + passing tests + README snippet",
     "write": true // Allow changes - will launch every agent in a separate worktree
   }
 }
 agent {"action":"wait","wait":{"batch_id":"<batch_id>","return_all":true,"timeout_seconds":600}} // Long timeout or you can do separate work and check back later.
 
-##  Model Guide for `agent.create.models`
+##  Agent/Model Selector Guide for `agent.create.models`
 {MODEL_DESCRIPTIONS}
 
 # WARNING (using git)

--- a/code-rs/core/src/agent_tool.rs
+++ b/code-rs/core/src/agent_tool.rs
@@ -2443,7 +2443,7 @@ pub fn create_agent_tool(allowed_models: &[String]) -> OpenAiTool {
                 },
             }),
                 description: Some(
-                    "Optional array of agent/model selectors (e.g., ['code-gpt-5.5','code-gpt-5.4','claude-sonnet-4.6','antigravity']; antigravity launches agy and uses Antigravity's configured model)".to_string(),
+                    "Optional array of agent/model selector slugs (e.g., ['code-gpt-5.5','claude-sonnet-4.6','antigravity']; external CLI selectors use that tool's configured model)".to_string(),
                 ),
         },
     );


### PR DESCRIPTION
## Summary
- keep `agent.create.models` as the stable tool field after live harness validation
- tighten the tool schema description to call entries agent/model selector slugs
- rename the prompt guide heading without adding a larger explanation block

## Validation
- `code exec --json --sandbox read-only --max-seconds 240 ...` live harness: GPT-5.5 called `agent.create` with `models: ["antigravity"]`, Antigravity launched, and returned `AGENT_OK`
- `cargo test -p code-core antigravity_receives_workspace_add_dir -- --nocapture`
- `cargo test -p code-core agent_tool -- --nocapture`
- `git diff --check`
- `./build-fast.sh`

Refs #99
Refs #134
