### PR TITLE
Preserve codex npm command alias

### DIFF
--- a/codex-cli/.pack/package/package.json
+++ b/codex-cli/.pack/package/package.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {
-    "coder": "bin/coder.js"
+    "coder": "bin/coder.js",
+    "codex": "bin/coder.js"
   },
   "type": "module",
   "engines": {

--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
-        "coder": "bin/coder.js"
+        "coder": "bin/coder.js",
+        "codex": "bin/coder.js"
       },
       "devDependencies": {
         "prettier": "^3.3.3"

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {
-    "coder": "bin/coder.js"
+    "coder": "bin/coder.js",
+    "codex": "bin/coder.js"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- keep the removed stale `bin/codex.js` implementation out of the npm package
- preserve the `codex` command alias by pointing it at the maintained `bin/coder.js` wrapper
- align `package-lock.json` and the checked-in `.pack` metadata with the alias

## Validation
- `git diff --check`
- `npm pack --dry-run` from `codex-cli`
- temp-prefix install smoke verified both `coder` and `codex` symlink to `../@just-every/code/bin/coder.js`
- `./build-fast.sh`

Follow-up to #171. Refs #130.
