### PR TITLE
Refresh stale Code defaults in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   See commit `60727b068` and related Auto Drive hardening commits in git history for details.
 
 
-- **Auto Review** – background ghost-commit watcher runs reviews in a separate worktree whenever a turn changes code; uses `codex-5.1-mini-high` and reports issues plus ready-to-apply fixes without blocking the main thread.
+- **Auto Review** – background ghost-commit watcher runs reviews in a separate worktree whenever a turn changes code; uses the configured review model and reports issues plus ready-to-apply fixes without blocking the main thread.
 - **Code Bridge** – Sentry-style local bridge that streams errors, console, screenshots, and control from running apps into Code; ships an MCP server.
 - **Plays well with Auto Drive** – reviews run in parallel with long Auto Drive tasks so quality checks land while the flow keeps moving.
 - **Quality-first focus** – the release shifts emphasis from "can the model write this file" to "did we verify it works".

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,7 +22,7 @@ Every Code supports several mechanisms for setting config values:
 The model that Code should use.
 
 ```toml
-model = "o3"  # overrides the default of "gpt-5.1-codex"
+model = "o3"  # overrides the default of "gpt-5.5"
 ```
 
 ## model_providers
@@ -294,7 +294,7 @@ Users can specify config values at multiple levels. Order of precedence is as fo
 1. custom command-line argument, e.g., `--model o3`
 2. as part of a profile, where the `--profile` is specified via a CLI (or in the config file itself)
 3. as an entry in `config.toml`, e.g., `model = "o3"`
-4. the default value that comes with Code CLI (i.e., Code CLI defaults to `gpt-5.1-codex`)
+4. the default value that comes with Code CLI (i.e., Code CLI defaults to `gpt-5.5`)
 
 ## model_reasoning_effort
 
@@ -1038,7 +1038,7 @@ Project commands appear in the TUI via `/cmd <name>` and run through the standar
 
 | Key | Type / Values | Notes |
 | --- | --- | --- |
-| `model` | string | Model to use (e.g., `gpt-5.1-codex`). |
+| `model` | string | Model to use (e.g., `gpt-5.5`). |
 | `model_provider` | string | Provider id from `model_providers` (default: `openai`). |
 | `model_context_window` | number | Context window tokens. |
 | `model_max_output_tokens` | number | Max output tokens. |

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -1,11 +1,11 @@
 # Sample configuration
 
-Use this example configuration as a starting point. For an explanation of each field and additional context, see [Configuration](./config.md). Copy the snippet below to `~/.codex/config.toml` and adjust values as needed.
+Use this example configuration as a starting point. For an explanation of each field and additional context, see [Configuration](./config.md). Copy the snippet below to `~/.code/config.toml` and adjust values as needed.
 
 ```toml
-# Codex example configuration (config.toml)
+# Code example configuration (config.toml)
 #
-# This file lists all keys Codex reads from config.toml, their default values,
+# This file lists all keys Code reads from config.toml, their default values,
 # and concise explanations. Values here mirror the effective defaults compiled
 # into the CLI. Adjust as needed.
 #
@@ -18,11 +18,11 @@ Use this example configuration as a starting point. For an explanation of each f
 # Core Model Selection
 ################################################################################
 
-# Primary model used by Codex. Default: "gpt-5.1-codex-max" on all platforms.
-model = "gpt-5.1-codex-max"
+# Primary model used by Code. Default: "gpt-5.5" on all platforms.
+model = "gpt-5.5"
 
-# Model used by the /review feature (code reviews). Default: "gpt-5.1-codex-max".
-review_model = "gpt-5.1-codex-max"
+# Model used by the /review feature (code reviews). Default: "gpt-5.5".
+review_model = "gpt-5.5"
 
 # Provider id selected from [model_providers]. Default: "openai".
 model_provider = "openai"
@@ -31,7 +31,7 @@ model_provider = "openai"
 # Uncomment to force values.
 # model_context_window = 128000       # tokens; default: auto for model
 # model_auto_compact_token_limit = 0  # disable/override auto; default: model family specific
-# tool_output_token_limit = 10000  # tokens stored per tool output; default: 10000 for gpt-5.1-codex-max
+# tool_output_token_limit = 10000  # tokens stored per tool output
 
 ################################################################################
 # Reasoning & Verbosity (Responses API capable models)
@@ -299,7 +299,7 @@ experimental_use_freeform_apply_patch = false
 [profiles]
 
 # [profiles.default]
-# model = "gpt-5.1-codex-max"
+# model = "gpt-5.5"
 # model_provider = "openai"
 # approval_policy = "on-request"
 # sandbox_mode = "read-only"

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,29 +2,29 @@
 
 > **Warning:** This is an experimental and non-stable feature. If you depend on it, please expect breaking changes over the coming weeks and understand that there is currently no guarantee that this works well. Use at your own risk!
 
-Codex can automatically discover reusable "skills" you keep on disk. A skill is a small bundle with a name, a short description (what it does and when to use it), and an optional body of instructions you can open when needed. Codex injects only the name, description, and file path into the runtime context; the body stays on disk.
+Code can automatically discover reusable "skills" you keep on disk. A skill is a small bundle with a name, description, and optional body of instructions you can open when needed. Code injects only implicitly invokable skill metadata into runtime context; the body stays on disk.
 
 ## Enable skills
 
 Skills are behind the experimental `skills` feature flag and are enabled by default.
 
-- Disable in config (preferred): add the following to `$CODEX_HOME/config.toml` (usually `~/.codex/config.toml`) and restart Codex:
+- Disable in config (preferred): add the following to `$CODE_HOME/config.toml` (usually `~/.code/config.toml`) and restart Code:
 
   ```toml
   [features]
   skills = false
   ```
 
-- Override for a single run when disabled in config: launch Codex with `codex --enable skills`
+- Override for a single run when disabled in config: launch Code with `code --enable skills`.
 
 ## Where skills live
 
 - Discovery roots (highest precedence first):
   - Repo: `.agents/skills/**/SKILL.md` from the current working directory up to the repo root.
   - Repo (legacy): `.codex/skills/**/SKILL.md` from the current working directory up to the repo root.
-  - User: `$HOME/.agents/skills/**/SKILL.md`.
-  - User (legacy): `$CODEX_HOME/skills/**/SKILL.md` (usually `~/.code/skills`; legacy `~/.codex/skills` is still read for compatibility).
-  - System: bundled skills under `$CODEX_HOME/skills/.system/**/SKILL.md`.
+  - User agents: `$HOME/.agents/skills/**/SKILL.md`.
+  - User Code home: `$CODE_HOME/skills/**/SKILL.md` (usually `~/.code/skills`; legacy `$CODEX_HOME`/`~/.codex` is still read for compatibility).
+  - System: bundled skills under `$CODE_HOME/skills/.system/**/SKILL.md`.
   - Admin (optional): `/etc/codex/skills/**/SKILL.md`.
 - Discovery is recursive and only files named exactly `SKILL.md` count.
 - Hidden entries are skipped.
@@ -36,14 +36,17 @@ Skills are behind the experimental `skills` feature flag and are enabled by defa
 
 - YAML frontmatter + body.
   - Required:
-    - `name` (non-empty, ≤100 chars, sanitized to one line)
-    - `description` (non-empty, ≤500 chars, sanitized to one line)
-  - Extra keys are ignored. The body can contain any Markdown; it is not injected into context.
+    - `name` (non-empty, <=64 chars, sanitized to one line)
+    - `description` (non-empty, <=1024 chars, sanitized to one line)
+  - Optional:
+    - `metadata.short-description` (non-empty when present, <=160 chars)
+    - `policy.allow_implicit_invocation` (`true` by default; set `false` for manual-only skills)
+  - The body can contain any Markdown; it is not injected into context until the skill is opened.
 
 ## Loading and rendering
 
 - Loaded once at startup.
-- If valid skills exist, Codex appends a runtime-only `## Skills` section after `AGENTS.md`, one bullet per skill: `- <name>: <description> (file: /absolute/path/to/SKILL.md)`.
+- If valid implicitly invokable skills exist, Code appends a runtime-only `## Skills` section after `AGENTS.md`, one bullet per skill: `- <name>: <description> (file: /absolute/path/to/SKILL.md)`.
 - If no valid skills exist, the section is omitted. On-disk files are never modified.
 
 ## Using skills
@@ -57,34 +60,39 @@ Skills are behind the experimental `skills` feature flag and are enabled by defa
 
 ## Create a skill
 
-1. Create `~/.codex/skills/<skill-name>/`.
+1. Create `~/.code/skills/<skill-name>/`.
 2. Add `SKILL.md`:
 
-   ```
+   ```markdown
    ---
    name: your-skill-name
-   description: what it does and when to use it (<=500 chars)
+   description: what it does and when to use it
+   metadata:
+     short-description: short picker label (optional)
+   policy:
+     allow_implicit_invocation: true
    ---
 
    # Optional body
    Add instructions, references, examples, or scripts (kept on disk).
    ```
 
-3. Keep `name`/`description` within the limits; avoid newlines in those fields.
-4. Restart Codex to load the new skill.
+3. Keep frontmatter fields within their limits; avoid newlines in single-line fields.
+4. Restart Code to load the new skill.
 
 ## Example
 
-```
-mkdir -p ~/.codex/skills/pdf-processing
-cat <<'SKILL_EXAMPLE' > ~/.codex/skills/pdf-processing/SKILL.md
+Create `~/.code/skills/pdf-processing/SKILL.md`:
+
+```markdown
 ---
 name: pdf-processing
 description: Extract text and tables from PDFs; use when PDFs, forms, or document extraction are mentioned.
+metadata:
+  short-description: PDF extraction helper
 ---
 
 # PDF Processing
 - Use pdfplumber to extract text.
 - For form filling, see FORMS.md.
-SKILL_EXAMPLE
 ```


### PR DESCRIPTION
## Summary
- update skills docs from Codex-era commands/paths to Code-first paths while preserving compatibility notes
- document current skill frontmatter limits plus `metadata.short-description` and manual-only invocation policy
- replace stale default-model references with the current `gpt-5.5` default and avoid hard-coding an old Auto Review model in the README

## Validation
- targeted grep for stale defaults/commands in touched docs
- `git diff --check`
- `./build-fast.sh`

Refs #130
