### PR TITLE
Avoid mandatory codex npm shim

### DIFF
--- a/codex-cli/.pack/package/package.json
+++ b/codex-cli/.pack/package/package.json
@@ -4,8 +4,7 @@
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {
-    "coder": "bin/coder.js",
-    "codex": "bin/coder.js"
+    "coder": "bin/coder.js"
   },
   "type": "module",
   "engines": {

--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -10,8 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
-        "coder": "bin/coder.js",
-        "codex": "bin/coder.js"
+        "coder": "bin/coder.js"
       },
       "devDependencies": {
         "prettier": "^3.3.3"

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -4,8 +4,7 @@
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {
-    "coder": "bin/coder.js",
-    "codex": "bin/coder.js"
+    "coder": "bin/coder.js"
   },
   "type": "module",
   "engines": {

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -92,4 +92,4 @@ quoted_args=""
 for arg in "$@"; do
   quoted_args+=" $(printf '%q' "$arg")"
 done
-docker exec -it "$CONTAINER_NAME" bash -c "cd \"/app$WORK_DIR\" && codex --sandbox workspace-write --ask-for-approval on-request ${quoted_args}"
+docker exec -it "$CONTAINER_NAME" bash -c "cd \"/app$WORK_DIR\" && coder --sandbox workspace-write --ask-for-approval on-request ${quoted_args}"


### PR DESCRIPTION
## Summary
- remove the published npm codex bin alias so installs do not clobber existing codex shims
- update the container helper to invoke coder inside the container
- keep the packaged metadata aligned with the root package metadata

## Validation
- rg -n '"codex"\s*:|bin/codex\.js|\bcodex --sandbox|&& codex --' codex-cli package.json
- npm pack --dry-run
- temp global-prefix npm install with an existing codex shim; verified coder installs and codex remains untouched
- git diff --check
- ./build-fast.sh

Follow-up to #172; refs #130