### PR TITLE
Update protocol image error branding

### DIFF
--- a/code-rs/protocol/src/models.rs
+++ b/code-rs/protocol/src/models.rs
@@ -723,7 +723,7 @@ fn local_image_error_placeholder(
 ) -> ContentItem {
     ContentItem::InputText {
         text: format!(
-            "Codex could not read the local image at `{}`: {}",
+            "Code could not read the local image at `{}`: {}",
             path.display(),
             error
         ),
@@ -788,7 +788,7 @@ fn invalid_image_error_placeholder(
 fn unsupported_image_error_placeholder(path: &std::path::Path, mime: &str) -> ContentItem {
     ContentItem::InputText {
         text: format!(
-            "Codex cannot attach image at `{}`: unsupported image format `{}`.",
+            "Code cannot attach image at `{}`: unsupported image format `{}`.",
             path.display(),
             mime
         ),
@@ -2271,7 +2271,7 @@ mod tests {
             ResponseInputItem::Message { content, .. } => {
                 assert_eq!(content.len(), 1);
                 let expected = format!(
-                    "Codex cannot attach image at `{}`: unsupported image format `image/svg+xml`.",
+                    "Code cannot attach image at `{}`: unsupported image format `image/svg+xml`.",
                     svg_path.display()
                 );
                 match &content[0] {


### PR DESCRIPTION
## Summary
- change user-visible protocol image placeholder errors from Codex to Code
- update the matching unsupported-image test expectation

## Validation
- cargo test -p code-protocol local_image -- --nocapture
- git diff --check
- ./build-fast.sh

Refs #130