### PR TITLE
Add Every Code naming ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,25 @@ Repo workflow metadata lives in `.github/github.json`; keep that
 file aligned with branch roles, validation gates, GitHub signal capabilities,
 workflow names, docs routing, and local cleanup policy when those facts change.
 
-Every Code is the product in this repository; `code` is the CLI shorthand.
-Upstream Codex and just-every/code are provenance and import sources, not the
-repo's product identity.
+Every Code is the product in this repository; `code` is the command users type.
+Use **Every Code** for the product name in prose, docs, UI copy, issue text,
+release text, and first mentions. Use **Every Code CLI** for the product CLI
+surface, and **the `code` command** when referring to the executable. Use **the
+Every Code agent** for the assistant identity; **Code** is only a short display
+name after Every Code context is established. Use **Every Code harness** for the
+runtime/session wrapper that we restart and dogfood, and **Every Code runtime**
+for process/session/tool-execution internals.
+
+Upstream import sources are `just-every/code` and `openai/codex`. Treat
+`just-every/code` as a fork upstream/import source. Treat `openai/codex` / Codex
+CLI as the original/direct upstream and provenance source. `codex-rs` is a
+read-only local mirror of `openai/codex:main`; edit Rust sources under
+`code-rs`, the Every Code product implementation.
+
+`CODE_HOME` / `~/.code` are the primary config and state locations.
+`CODEX_HOME` / `~/.codex` are compatibility fallbacks. Keep `CODEX_*` names when
+they are part of external, backend, or upstream compatibility; add `CODE_*`
+aliases or rename only through a scoped migration.
 
 Rust implementation lives under `code-rs`:
 

--- a/docs/local-overlay.md
+++ b/docs/local-overlay.md
@@ -1,8 +1,29 @@
 # Upstream Import And Local Runtime Policy
 
 Every Code owns its product direction, defaults, releases, and UX. `main` is the
-canonical product branch and GitHub default branch for the local `code` binary on
+canonical product branch and GitHub default branch for the local `code` command on
 this machine.
+
+## Naming Ledger
+
+- **Every Code** is the product name. Use it in prose, docs, UI copy, issue text,
+  release text, and first mentions.
+- **Every Code CLI** is the product CLI surface. **The `code` command** is the
+  executable users type. Avoid “code CLI” in prose.
+- **The Every Code agent** is the assistant identity. **Code** is only a short
+  display name after Every Code context is established.
+- **Every Code harness** is the runtime/session wrapper that we restart and
+  dogfood. **Every Code runtime** is appropriate for process, session, and tool
+  execution internals.
+- **Upstream import sources** are `just-every/code` and `openai/codex`.
+  `just-every/code` is a fork upstream/import source. `openai/codex` / Codex CLI
+  is the original/direct upstream and provenance source.
+- `codex-rs/` is a read-only local mirror of `openai/codex:main`. `code-rs/` is
+  the editable Every Code Rust implementation.
+- `CODE_HOME` / `~/.code` are primary config and state locations. `CODEX_HOME` /
+  `~/.codex` are compatibility fallbacks. Keep `CODEX_*` names where external,
+  backend, or upstream compatibility requires them; add `CODE_*` aliases or
+  rename only through scoped migrations.
 
 The pre-cutover `origin/main` history was archived at
 `archive/pre-every-code-main-2026-05-24` before `main` was repointed to the Every
@@ -14,11 +35,12 @@ changes under `code-rs/`.
 
 Remote map:
 
-- `upstream`: `just-every/code`, the normal import source.
+- `upstream`: `just-every/code`, a fork upstream/import source.
 - `origin` / `fork`: `cbusillo/code`, where Every Code product branches and tags
   are pushed.
-- `openai`: reference remote for `openai/codex`; do not use it for routine
-  imports or pushes.
+- `openai`: remote for `openai/codex`, the original/direct upstream and
+  provenance source. Use it for direct upstream intake when intentional; do not
+  push Every Code changes there.
 
 ## Every Code-Owned Surfaces
 


### PR DESCRIPTION
## Summary
- add canonical naming rules for Every Code, Every Code CLI, the `code` command, the Every Code agent, harness, and runtime
- clarify upstream import source wording for `just-every/code`, `openai/codex`, `codex-rs`, and `code-rs`
- document `CODE_HOME`/`~/.code` as primary and `CODEX_HOME`/`~/.codex` as compatibility fallback

## Validation
- git diff --check
- ./build-fast.sh

Refs #179
Refs #180