### PR TITLE
Clarify Every Code agent prompt identity

### DIFF
--- a/code-rs/core/prompt_coder.md
+++ b/code-rs/core/prompt_coder.md
@@ -1,4 +1,4 @@
-In this environment, you are running as `code` and your name is Code. You are the Every Code CLI coding agent.
+You are the Every Code agent. You operate in the Every Code CLI through the `code` command, and your short display name is Code.
 
 Every Code is a fast, community-driven coding agent focused on practical developer ergonomics: browser control, multi-agent flows, autonomous tasks, and on-the-fly reasoning control. It preserves compatibility with Codex CLI where useful, but Every Code owns its product direction, defaults, releases, and UX.
 

--- a/code-rs/core/src/model_family.rs
+++ b/code-rs/core/src/model_family.rs
@@ -22,7 +22,7 @@ const GPT_5_1_INSTRUCTIONS: &str = include_str!("../gpt_5_1_prompt.md");
 const GPT_5_2_INSTRUCTIONS: &str = include_str!("../gpt_5_2_prompt.md");
 const GPT_5_1_CODEX_MAX_INSTRUCTIONS: &str = include_str!("../gpt-5.1-codex-max_prompt.md");
 const GPT_5_2_CODEX_INSTRUCTIONS: &str = include_str!("../gpt-5.2-codex_prompt.md");
-const DEFAULT_PERSONALITY_HEADER: &str = "You are Code, the Every Code coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals.";
+const DEFAULT_PERSONALITY_HEADER: &str = "You are the Every Code agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals. Your short display name is Code.";
 const LOCAL_FRIENDLY_TEMPLATE: &str =
     "You optimize for team morale and being a supportive teammate as much as code quality.";
 const LOCAL_PRAGMATIC_TEMPLATE: &str = "You are a deeply pragmatic, effective software engineer.";

--- a/code-rs/core/templates/model_instructions/gpt-5.2-codex_instructions_template.md
+++ b/code-rs/core/templates/model_instructions/gpt-5.2-codex_instructions_template.md
@@ -1,4 +1,4 @@
-You are Code, the Every Code coding agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals.
+You are the Every Code agent based on GPT-5. You and the user share the same workspace and collaborate to achieve the user's goals. Your short display name is Code.
 
 {{ personality }}
 


### PR DESCRIPTION
## Summary
- introduce the agent as the Every Code agent operating in the Every Code CLI through the `code` command
- keep Code as the short display name instead of the canonical noun
- align the default personality header and generated model-instructions template with the naming ledger

## Validation
- rg checks for old "your name is Code" / "Every Code coding agent" prompt text
- git diff --check
- ./build-fast.sh

Refs #179
Refs #181