### PR TITLE
Clarify Every Code visible naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 
 - **Auto Review** – background ghost-commit watcher runs reviews in a separate worktree whenever a turn changes code; uses the configured review model and reports issues plus ready-to-apply fixes without blocking the main thread.
-- **Code Bridge** – Sentry-style local bridge that streams errors, console, screenshots, and control from running apps into Code; ships an MCP server.
+- **Code Bridge** – Sentry-style local bridge that streams errors, console, screenshots, and control from running apps into Every Code; ships an MCP server.
 - **Plays well with Auto Drive** – reviews run in parallel with long Auto Drive tasks so quality checks land while the flow keeps moving.
 - **Quality-first focus** – the release shifts emphasis from "can the model write this file" to "did we verify it works".
 - _From v0.5.0:_ rename to Every Code, upgraded `/auto` planning/recovery, unified `/settings`, faster streaming/history with card-based activity, and more reliable `/resume` + `/undo`.
@@ -103,7 +103,7 @@ distribution becomes intentional again.
 
 ### Install External Agents (optional)
 
-Every Code supports orchestrating other AI CLI tools. Install these and config to use alongside Code.
+Every Code supports orchestrating other AI CLI tools. Install these and config to use alongside Every Code.
 
 ```bash
 # Ensure Node.js 20+ is available locally (installs into ~/.n)

--- a/code-rs/login/src/assets/success.html
+++ b/code-rs/login/src/assets/success.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
-    <title>Sign into Codex</title>
+    <title>Sign into Every Code</title>
     <link rel="icon" href='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 32 32"%3E%3Cpath stroke="%23000" stroke-linecap="round" stroke-width="2.484" d="M22.356 19.797H17.17M9.662 12.29l1.979 3.576a.511.511 0 0 1-.005.504l-1.974 3.409M30.758 16c0 8.15-6.607 14.758-14.758 14.758-8.15 0-14.758-6.607-14.758-14.758C1.242 7.85 7.85 1.242 16 1.242c8.15 0 14.758 6.608 14.758 14.758Z"/%3E%3C/svg%3E' type="image/svg+xml">
     <style>
       :root {
@@ -169,7 +169,7 @@
           <div class="logo">
             <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 32 32"><path stroke="#000" stroke-linecap="round" stroke-width="2.484" d="M22.356 19.797H17.17M9.662 12.29l1.979 3.576a.511.511 0 0 1-.005.504l-1.974 3.409M30.758 16c0 8.15-6.607 14.758-14.758 14.758-8.15 0-14.758-6.607-14.758-14.758C1.242 7.85 7.85 1.242 16 1.242c8.15 0 14.758 6.608 14.758 14.758Z"></path></svg>
           </div>
-          <div class="title">Signed in to Codex</div>
+          <div class="title">Signed in to Every Code</div>
         </div>
         <div class="close-box" style="display: none;">
           <div class="setup-description">You may now close this page</div>

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -43,12 +43,12 @@ code exec resume 7f9f9a2e-1b3c-4c7a-9b0e-123456789abc "continue the task"
 
 Notes:
 
-- When using `--last`, Code picks the newest recorded session; if none exist, it behaves like starting fresh.
+- When using `--last`, Every Code picks the newest recorded session; if none exist, it behaves like starting fresh.
 - Resuming appends new events to the existing session file and maintains the same conversation id.
 
 ## Tracing / verbose logging
 
-Because Code is written in Rust, it honors the `RUST_LOG` environment variable to configure its logging behavior.
+Because Every Code is written in Rust, it honors the `RUST_LOG` environment variable to configure its logging behavior.
 
 When you run the TUI with `--debug`, log messages are written to `~/.code/debug_logs/codex-tui.log`, so you can leave the following running in a separate terminal to monitor log messages as they are written:
 
@@ -74,7 +74,7 @@ subdirectories such as:
 Tags become nested path components, so custom helpers appear alongside the
 existing timestamped filenames.
 
-Without `--debug`, Code only writes critical crash/error logs to
+Without `--debug`, Every Code only writes critical crash/error logs to
 `~/.code/debug_logs/critical.log.*`; routine log output is suppressed.
 
 By comparison, the non-interactive mode (`code exec`) defaults to `RUST_LOG=error`, but messages are printed inline, so there is no need to monitor a separate file.
@@ -83,7 +83,7 @@ See the Rust documentation on [`RUST_LOG`](https://docs.rs/env_logger/latest/env
 
 ## Model Context Protocol (MCP)
 
-The Code CLI can be configured to leverage MCP servers by defining an [`mcp_servers`](./config.md#mcp_servers) section in `~/.code/config.toml` (Code will also read a legacy `~/.codex/config.toml`). It is intended to mirror how tools such as Claude and Cursor define `mcpServers` in their respective JSON config files, though the Code format is slightly different since it uses TOML rather than JSON, e.g.:
+The Every Code CLI can be configured to leverage MCP servers by defining an [`mcp_servers`](./config.md#mcp_servers) section in `~/.code/config.toml` (Every Code will also read a legacy `~/.codex/config.toml`). It is intended to mirror how tools such as Claude and Cursor define `mcpServers` in their respective JSON config files, though the Every Code format is slightly different since it uses TOML rather than JSON, e.g.:
 
 ```toml
 # IMPORTANT: the top-level key is `mcp_servers` rather than `mcpServers`.
@@ -95,4 +95,4 @@ env = { "API_KEY" = "value" }
 
 ## Using Code as an MCP Server
 > [!TIP]
-> It is somewhat experimental, but the Code CLI can also be run as an MCP _server_ via `code mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector code mcp` and send it a `tools/list` request, you will see that there is only one tool, `code`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues. 
+> It is somewhat experimental, but the Every Code CLI can also be run as an MCP _server_ via `code mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector code mcp` and send it a `tools/list` request, you will see that there is only one tool, `code`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -19,7 +19,7 @@ instructions = "Preamble added to this agent’s prompt"
 Field recap: `name` (slug/alias), `command` (absolute paths ok), `args*` (RO/RW lists override base), `env`, `read_only`, `enabled`, optional `description` and `instructions`.
 
 ### Built-in defaults
-If no `[[agents]]` are configured, Code advertises built-in agent/model selectors (gated by env `CODE_ENABLE_CLOUD_AGENT_MODEL` for cloud variants): `code-gpt-5.5`, `code-gpt-5.4`, `code-gpt-5.4-mini`, `claude-opus-4.6`, `antigravity`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `qwen3-coder-plus`, `cloud-gpt-5.1-codex-max`. Built-ins strip any user `--model/-m` flags to avoid conflicts and inject their own when the target CLI supports model flags.
+If no `[[agents]]` are configured, Every Code advertises built-in agent/model selectors (gated by env `CODE_ENABLE_CLOUD_AGENT_MODEL` for cloud variants): `code-gpt-5.5`, `code-gpt-5.4`, `code-gpt-5.4-mini`, `claude-opus-4.6`, `antigravity`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `qwen3-coder-plus`, `cloud-gpt-5.1-codex-max`. Built-ins strip any user `--model/-m` flags to avoid conflicts and inject their own when the target CLI supports model flags.
 
 Tip: `antigravity` uses Google's Antigravity CLI (`agy`) as the Google-agent path. Consumer Gemini CLI is no longer a built-in default; configure it manually only when you intentionally rely on enterprise/API-key Gemini CLI access.
 
@@ -29,13 +29,13 @@ Tip: `antigravity` uses Google's Antigravity CLI (`agy`) as the Google-agent pat
 name = "plan"                     # slash name (/plan, /solve, /code, or custom)
 read_only = true                  # default plan/solve=true, code=false
 agents = ["code-gpt-5.4", "claude-opus-4.6"]  # falls back to enabled agents or built-ins
-orchestrator_instructions = "Guidance for Code before spawning agents"
+orchestrator_instructions = "Guidance for the Every Code agent before spawning agents"
 agent_instructions = "Preamble added to each spawned agent"
 ```
 - `name`: slash command created/overridden.
 - `read_only`: forces spawned agents to RO when true.
 - `agents`: explicit list; empty → enabled `[[agents]]`; none configured → built-in roster.
-- `orchestrator_instructions`: appended to the Code-side prompt before issuing `agent.create`.
+- `orchestrator_instructions`: appended to the Every Code agent's prompt before issuing `agent.create`.
 - `agent_instructions`: appended to each spawned agent prompt.
 
 The orchestrator fans out agents, waits for results, and merges reasoning according to your `hide_agent_reasoning` / `show_raw_agent_reasoning` settings.
@@ -52,7 +52,7 @@ The orchestrator fans out agents, waits for results, and merges reasoning accord
 - `AUTO_AGENTS.md` is read alongside `AGENTS.md` for Auto Drive–specific guidance.
 
 ## AGENTS.md and project memory
-- Code loads AGENTS.md files along the path (global, repo root, cwd) up to 32 KiB total; deeper files override higher-level ones.
+- Every Code loads AGENTS.md files along the path (global, repo root, cwd) up to 32 KiB total; deeper files override higher-level ones.
 - Contents become system/developer instructions on the first turn; direct user/developer prompts still take precedence.
 
 ## Windows discovery tips

--- a/docs/auto-drive.md
+++ b/docs/auto-drive.md
@@ -3,7 +3,7 @@
 What Auto Drive is, how to start it, and how it behaves in Every Code.
 
 ## Start points
-- TUI: `/auto <goal>`. If you omit the goal and there is recent history, Code proposes one for you. `/auto settings` jumps straight to the Auto Drive pane.
+- TUI: `/auto <goal>`. If you omit the goal and there is recent history, Every Code proposes one for you. `/auto settings` jumps straight to the Auto Drive pane.
 - CLI: `code exec --auto "<goal>"` or `code exec "/auto <goal>"`. A goal is required when launching headless.
 - Precondition: Full Auto mode (danger-full-access + approval=never) must be selected in the TUI; otherwise you’ll see a warning and Auto Drive will not start.
 
@@ -43,8 +43,8 @@ What Auto Drive is, how to start it, and how it behaves in Every Code.
 
 ## Crash diagnostics
 - Set `CODEX_TUI_RECORD_SESSION=1` to persist a per-session JSONL trace of inbound TUI events, including Auto Drive coordinator decisions, countdowns, token metrics, and panic records.
-- Optionally set `CODEX_TUI_SESSION_LOG_PATH=/absolute/path/session.jsonl` to choose the output file; otherwise Code writes under its normal log directory (typically `~/.code/debug_logs/`, and `code-dev` defaults to `~/.code/debug_logs/code-dev/`).
-- When the TUI panics, Code now records the panic payload and captured backtrace in both the session JSONL log and the regular error log.
+- Optionally set `CODEX_TUI_SESSION_LOG_PATH=/absolute/path/session.jsonl` to choose the output file; otherwise Every Code writes under its normal log directory (typically `~/.code/debug_logs/`, and `code-dev` defaults to `~/.code/debug_logs/code-dev/`).
+- When the TUI panics, Every Code now records the panic payload and captured backtrace in both the session JSONL log and the regular error log.
 
 ## Models
 - Defaults: model `gpt-5.1`, reasoning effort `high`.

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -6,13 +6,13 @@ Use Every Code in non-interactive mode to automate common workflows.
 code exec "count the total number of lines of code in this project"
 ```
 
-In non-interactive mode, Code does not ask for command or edit approvals. By default it runs in `read-only` mode, so it cannot edit files or run commands that require network access.
+In non-interactive mode, Every Code does not ask for command or edit approvals. By default it runs in `read-only` mode, so it cannot edit files or run commands that require network access.
 
 Use `code exec --full-auto` to allow file edits. Use `code exec --sandbox danger-full-access` to allow edits and networked commands.
 
 ### Default output mode
 
-By default, Code streams its activity to stderr and only writes the final message from the agent to stdout. This makes it easier to pipe `code exec` into another tool without extra filtering.
+By default, Every Code streams its activity to stderr and only writes the final message from the agent to stdout. This makes it easier to pipe `code exec` into another tool without extra filtering.
 
 To write the output of `code exec` to a file, in addition to using a shell redirect like `>`, there is also a dedicated flag to specify an output file: `-o`/`--output-last-message`.
 
@@ -83,7 +83,7 @@ Combine `--output-schema` with `-o` to only print the final JSON output. You can
 
 ### Git repository requirement
 
-Code requires a Git repository to avoid destructive changes. To disable this check, use `code exec --skip-git-repo-check`.
+Every Code requires a Git repository to avoid destructive changes. To disable this check, use `code exec --skip-git-repo-check`.
 
 ### Resuming non-interactive sessions
 
@@ -94,7 +94,7 @@ code exec "Review the change, look for use-after-free issues"
 code exec resume --last "Fix use-after-free issues"
 ```
 
-Only the conversation context is preserved; you must still provide flags to customize Code behavior.
+Only the conversation context is preserved; you must still provide flags to customize Every Code behavior.
 
 ```shell
 code exec --model gpt-5.1-codex --json "Review the change, look for use-after-free issues"

--- a/docs/execpolicy.md
+++ b/docs/execpolicy.md
@@ -1,23 +1,23 @@
 # Execution policy
 
-Every Code can enforce your own rules-based execution policy before it runs shell commands. Policies live in Starlark `.codexpolicy` files under `~/.code/policy` (Code still reads `~/.codex/policy` for backward compatibility).
+Every Code can enforce your own rules-based execution policy before it runs shell commands. Policies live in Starlark `.codexpolicy` files under `~/.code/policy` (Every Code still reads `~/.codex/policy` for backward compatibility).
 
 ## How to create and edit rules
 
 ### TUI interactions
 
-Codex CLI will present the option to whitelist commands when a command causes a prompt.
+Every Code will present the option to whitelist commands when a command causes a prompt.
 
 <img width="513" height="168" alt="Screenshot 2025-12-04 at 9 23 54 AM" src="https://github.com/user-attachments/assets/4c8ee8ea-3101-4a81-bb13-3f4a9aa02502" />
 
 Whitelisted commands will no longer require your permission to run in current and subsequent sessions.
 
-Under the hood, when you approve and whitelist a command, codex will edit `~/.codex/rules/default.rules`.
+Under the hood, whitelisted commands are represented as `.codexpolicy` rules in the policy directory.
 
 ### Editing `.rules` files
 
 1. Create a policy directory: `mkdir -p ~/.code/policy`.
-2. Add one or more `.codexpolicy` files in that folder. Code automatically loads every `.codexpolicy` file in there on startup.
+2. Add one or more `.codexpolicy` files in that folder. Every Code automatically loads every `.codexpolicy` file in there on startup.
 3. Write `prefix_rule` entries to describe the commands you want to allow, prompt, or block:
 
 ```starlark
@@ -30,10 +30,10 @@ prefix_rule(
 ```
 
 - `pattern` is a list of shell tokens, evaluated from left to right; wrap tokens in a nested list to express alternatives (for example, match both `push` and `fetch`).
-- `decision` sets the severity; Code picks the strictest decision when multiple rules match (forbidden > prompt > allow).
-- `match` and `not_match` act as optional unit tests. Code validates them when it loads your policy, so you get feedback if an example has unexpected behavior.
+- `decision` sets the severity; Every Code picks the strictest decision when multiple rules match (forbidden > prompt > allow).
+- `match` and `not_match` act as optional unit tests. Every Code validates them when it loads your policy, so you get feedback if an example has unexpected behavior.
 
-In this example rule, if Code wants to run commands with the prefix `git push` or `git fetch`, it will first ask for user approval.
+In this example rule, if Every Code wants to run commands with the prefix `git push` or `git fetch`, it will first ask for user approval.
 
 ## Preview decisions
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Getting started with Codex CLI
+# Getting Started With Every Code
 
 ### CLI usage
 
@@ -12,7 +12,7 @@ Key flags: `--model/-m`, `--ask-for-approval/-a`.
 
 ### Running with a prompt as input
 
-You can also run the Code CLI with a prompt as input:
+You can also run the Every Code CLI with a prompt as input:
 
 ```shell
 code "explain this codebase to me"
@@ -22,7 +22,7 @@ code "explain this codebase to me"
 code --full-auto "create the fanciest todo-list app"
 ```
 
-That's it - Code will scaffold a file, run it inside a sandbox, install any
+That's it - Every Code will scaffold a file, run it inside a sandbox, install any
 missing dependencies, and show you the live result. Approve the changes and
 they'll be committed to your working directory.
 
@@ -32,7 +32,7 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 
 | ✨  | What you type                                                              | What happens                                                               |
 | --- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| 1   | `code "Refactor the Dashboard component to React Hooks"`                     | Code rewrites the class component, runs `npm test`, and shows the diff.    |
+| 1   | `code "Refactor the Dashboard component to React Hooks"`                     | Every Code rewrites the class component, runs `npm test`, and shows the diff. |
 | 2   | `code "Generate SQL migrations for adding a users table"`                    | Infers your ORM, creates migration files, and runs them in a sandboxed DB. |
 | 3   | `code "Write unit tests for utils/date.ts"`                                  | Generates tests, executes them, and iterates until they pass.              |
 | 4   | `code "Bulk-rename *.jpeg -> *.jpg with git mv"`                             | Safely renames files and updates imports/usages.                           |
@@ -42,9 +42,9 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 
 ### Memory with AGENTS.md
 
-You can give Every Code extra instructions and guidance using `AGENTS.md` files. Code looks for `AGENTS.md` files in the following places, and merges them top-down:
+You can give Every Code extra instructions and guidance using `AGENTS.md` files. Every Code looks for `AGENTS.md` files in the following places, and merges them top-down:
 
-1. `~/.code/AGENTS.md` - personal global guidance (Code will also read a legacy `~/.codex/AGENTS.md` if present)
+1. `~/.code/AGENTS.md` - personal global guidance (Every Code will also read a legacy `~/.codex/AGENTS.md` if present)
 2. `AGENTS.md` at repo root - shared project notes
 3. `AGENTS.md` in the current working directory - sub-folder/feature specifics
 
@@ -67,7 +67,7 @@ code --image img1.png,img2.jpg "Summarize these diagrams"
 
 #### Esc–Esc to edit a previous message
 
-When the chat composer is empty, press Esc to prime “backtrack” mode. Press Esc again to open a transcript preview highlighting the last user message; press Esc repeatedly to step to older user messages. Press Enter to confirm and Code will fork the conversation from that point, trim the visible transcript accordingly, and pre‑fill the composer with the selected user message so you can edit and resubmit it.
+When the chat composer is empty, press Esc to prime “backtrack” mode. Press Esc again to open a transcript preview highlighting the last user message; press Esc repeatedly to step to older user messages. Press Enter to confirm and Every Code will fork the conversation from that point, trim the visible transcript accordingly, and pre‑fill the composer with the selected user message so you can edit and resubmit it.
 
 In the transcript preview, the footer shows an `Esc edit prev` hint while editing is active.
 
@@ -83,4 +83,4 @@ code completion fish
 
 #### `--cd`/`-C` flag
 
-Sometimes it is not convenient to `cd` to the directory you want Code to use as the "working root" before running. Fortunately, `code` supports a `--cd` option so you can specify whatever folder you want. You can confirm that Code is honoring `--cd` by double-checking the **workdir** it reports in the TUI at the start of a new session.
+Sometimes it is not convenient to `cd` to the directory you want Every Code to use as the "working root" before running. Fortunately, `code` supports a `--cd` option so you can specify whatever folder you want. You can confirm that Every Code is honoring `--cd` by double-checking the **workdir** it reports in the TUI at the start of a new session.

--- a/docs/integration-zed.md
+++ b/docs/integration-zed.md
@@ -24,8 +24,8 @@ Adjust `command` to an absolute binary path if Zed cannot find `code` on PATH.
 ## How Every Code implements ACP
 
 - The Rust MCP server exposes ACP tools: `session/new`, `session/prompt`, and fast interrupts via `session/cancel`. These are backed by the same conversation manager that powers the TUI, so approvals, confirm guards, and sandbox policies remain intact.
-- Streaming `session/update` notifications bridge Code events into Zed. You get Answer/Reasoning updates, shell command progress, approvals, and apply_patch diffs in the Zed UI without losing terminal parity.
-- MCP configuration stays centralized in `CODE_HOME/config.toml` (Code also reads `CODEX_HOME/config.toml` for compatibility). Use `[experimental_client_tools]` to delegate file read/write and permission requests back to Zed when you want its UI to handle approvals. A minimal setup looks like:
+- Streaming `session/update` notifications bridge Every Code events into Zed. You get Answer/Reasoning updates, shell command progress, approvals, and apply_patch diffs in the Zed UI without losing terminal parity.
+- MCP configuration stays centralized in `CODE_HOME/config.toml` (Every Code also reads `CODEX_HOME/config.toml` for compatibility). Use `[experimental_client_tools]` to delegate file read/write and permission requests back to Zed when you want its UI to handle approvals. A minimal setup looks like:
 
 ```toml
 [experimental_client_tools]
@@ -39,7 +39,7 @@ Zed wires these tools automatically when you add the Code (Every Code) agent, so
 
 ## Tips and troubleshooting
 
-- Need to inspect the handshake? Run Zed’s `dev: open acp logs` command from the Command Palette; the log shows JSON‑RPC requests and Code replies.
+- Need to inspect the handshake? Run Zed’s `dev: open acp logs` command from the Command Palette; the log shows JSON‑RPC requests and Every Code replies.
 - If prompts hang, make sure no other process is bound to the same MCP port and that your `CODE_HOME` (or legacy `CODEX_HOME`) points to the intended config directory. The ACP server inherits all of Every Code’s sandbox settings, so restrictive policies (e.g., `approval_policy = "never"`) still apply.
 - Zed currently skips history restores and checkpoint UI for third-party agents. Stick to the TUI if you rely on those features; ACP support is still evolving upstream.
-- After a session starts, the model selector in Zed lists Every Code’s built-in presets (e.g., `gpt-5.1-codex`, `gpt-5.1` high/medium/low). Picking a new preset updates the running Code session immediately, so you don’t have to restart the agent to change models.
+- After a session starts, the model selector in Zed lists Every Code’s built-in presets (e.g., `gpt-5.1-codex`, `gpt-5.1` high/medium/low). Picking a new preset updates the running Every Code session immediately, so you don’t have to restart the agent to change models.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -2,7 +2,7 @@
 
 Save frequently used prompts as Markdown files and reuse them quickly from the slash menu.
 
-- Location: Put files in `$CODE_HOME/prompts/` (defaults to `~/.code/prompts/`; Code also reads legacy `~/.codex/prompts/`).
+- Location: Put files in `$CODE_HOME/prompts/` (defaults to `~/.code/prompts/`; Every Code also reads legacy `~/.codex/prompts/`).
 - File type: Only Markdown files with the `.md` extension are recognized.
 - Name: The filename without the `.md` extension becomes the slash entry. For a file named `my-prompt.md`, type `/my-prompt`.
 - Content: The file contents are sent as your message when you select the item in the slash popup and press Enter.
@@ -12,9 +12,9 @@ Save frequently used prompts as Markdown files and reuse them quickly from the s
   - `$$` is preserved literally
   - Quoted args: Wrap a single argument in double quotes to include spaces, e.g. `/review "docs/My File.md"`.
 - How to use:
-  - Start a new session (Code loads custom prompts on session start).
+  - Start a new session (Every Code loads custom prompts on session start).
   - In the composer, type `/` to open the slash popup and begin typing your prompt name.
   - Use Up/Down to select it. Press Enter to submit its contents, or Tab to autocomplete the name.
 - Notes:
   - Files with names that collide with built‑in commands (e.g. `/init`) are ignored and won’t appear.
-  - New or changed files are discovered on session start. If you add a new prompt while Code is running, start a new session to pick it up.
+  - New or changed files are discovered on session start. If you add a new prompt while Every Code is running, start a new session to pick it up.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,20 +2,20 @@
 
 > **Warning:** This is an experimental and non-stable feature. If you depend on it, please expect breaking changes over the coming weeks and understand that there is currently no guarantee that this works well. Use at your own risk!
 
-Code can automatically discover reusable "skills" you keep on disk. A skill is a small bundle with a name, description, and optional body of instructions you can open when needed. Code injects only implicitly invokable skill metadata into runtime context; the body stays on disk.
+Every Code can automatically discover reusable "skills" you keep on disk. A skill is a small bundle with a name, description, and optional body of instructions you can open when needed. Every Code injects only implicitly invokable skill metadata into runtime context; the body stays on disk.
 
 ## Enable skills
 
 Skills are behind the experimental `skills` feature flag and are enabled by default.
 
-- Disable in config (preferred): add the following to `$CODE_HOME/config.toml` (usually `~/.code/config.toml`) and restart Code:
+- Disable in config (preferred): add the following to `$CODE_HOME/config.toml` (usually `~/.code/config.toml`) and restart Every Code:
 
   ```toml
   [features]
   skills = false
   ```
 
-- Override for a single run when disabled in config: launch Code with `code --enable skills`.
+- Override for a single run when disabled in config: launch Every Code with `code --enable skills`.
 
 ## Where skills live
 
@@ -46,7 +46,7 @@ Skills are behind the experimental `skills` feature flag and are enabled by defa
 ## Loading and rendering
 
 - Loaded once at startup.
-- If valid implicitly invokable skills exist, Code appends a runtime-only `## Skills` section after `AGENTS.md`, one bullet per skill: `- <name>: <description> (file: /absolute/path/to/SKILL.md)`.
+- If valid implicitly invokable skills exist, Every Code appends a runtime-only `## Skills` section after `AGENTS.md`, one bullet per skill: `- <name>: <description> (file: /absolute/path/to/SKILL.md)`.
 - If no valid skills exist, the section is omitted. On-disk files are never modified.
 
 ## Using skills
@@ -78,7 +78,7 @@ Skills are behind the experimental `skills` feature flag and are enabled by defa
    ```
 
 3. Keep frontmatter fields within their limits; avoid newlines in single-line fields.
-4. Restart Code to load the new skill.
+4. Restart Every Code to load the new skill.
 
 ## Example
 

--- a/docs/tui-stream-chunking-validation.md
+++ b/docs/tui-stream-chunking-validation.md
@@ -23,7 +23,7 @@ Two trace messages are used:
 
 ## Runtime command
 
-Run Codex with chunking traces enabled:
+Run Every Code with chunking traces enabled:
 
 ```bash
 RUST_LOG='codex_tui::streaming::commit_tick=trace,codex_tui=info,codex_core=info,codex_rmcp_client=info' \
@@ -34,7 +34,7 @@ RUST_LOG='codex_tui::streaming::commit_tick=trace,codex_tui=info,codex_core=info
 
 Tip: for one-off measurements, run with `-c log_dir=...` to direct logs to a fresh directory and avoid mixing sessions.
 
-1. Record the current size of `~/.codex/log/codex-tui.log` as a start offset.
+1. Record the current size of `~/.code/debug_logs/codex-tui.log` as a start offset.
 2. Run an interactive prompt that produces sustained streamed output.
 3. Stop the run.
 4. Parse only log bytes written after the recorded offset.


### PR DESCRIPTION
## Summary
- update login success browser copy from Codex to Every Code
- refresh getting-started, exec, exec policy, skills, Auto Drive, and integration docs to use Every Code for product prose and reserve `code` for command examples
- keep Codex references where they are compatibility, upstream, model, or log/compatibility names

## Validation
- `rg -n "Signed in to Codex|Sign into Codex|Getting started with Codex CLI|Codex CLI will|Run Codex" README.md docs code-rs/login/src/assets/success.html --glob '!docs/release-notes/**'`
- `git diff --check`
- `./build-fast.sh`

Refs #179
Refs #182