### PR TITLE
Rename upstream import policy docs

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -6,7 +6,7 @@
   "docs": {
     "overview": "README.md",
     "agentGuide": "AGENTS.md",
-    "upstreamImportPolicy": "docs/local-overlay.md",
+    "upstreamImportPolicy": "docs/upstream-import-policy.md",
     "execution": "docs/exec.md",
     "sandboxing": "docs/platform-sandboxing.md",
     "tuiComposer": "docs/tui-chat-composer.md",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,15 +90,15 @@ Examples:
   `code-rs/target/release/code`.
 - Use `just local-upstream-import` only from a clean `main` branch. The helper
   fetches `upstream/main`, merges it into the current Every Code branch, replays
-  any commits listed in `scripts/local/overlay-picks.txt`, then rebuilds the
+  any commits listed in `scripts/local/upstream-picks.txt`, then rebuilds the
   release binary.
 - Commits already on the product branch persist automatically across future
   upstream imports. They do not need to be duplicated in
-  `scripts/local/overlay-picks.txt`.
+  `scripts/local/upstream-picks.txt`.
 - If you make a new Every Code fix that should remain part of the product,
   commit it through the normal task-branch/PR flow into the product branch
   first. Do not leave important local changes only as an unmerged side branch.
-- Add a commit SHA to `scripts/local/overlay-picks.txt` only for a patch that
+- Add a commit SHA to `scripts/local/upstream-picks.txt` only for a patch that
   intentionally lives outside the product branch and still needs to be
   cherry-picked in during `just local-upstream-import`. Keep the list ordered
   and comment each entry with the source branch or purpose.
@@ -106,10 +106,10 @@ Examples:
   do not need to merge cleanly as branches; only the specific carried commits
   must cherry-pick cleanly onto the current product branch.
 - If a legacy pick no longer cherry-picks cleanly, leave it commented out in
-  `scripts/local/overlay-picks.txt`, manually re-port the fix against current
+  `scripts/local/upstream-picks.txt`, manually re-port the fix against current
   upstream, commit the new port on the product branch, then replace the old SHA
   in the manifest if you still want automatic replay.
-- For Every Code-owned surfaces, release steps, remote names, and conflict hot spots, see `docs/local-overlay.md`.
+- For Every Code-owned surfaces, release steps, remote names, and conflict hot spots, see `docs/upstream-import-policy.md`.
 
 ## How to Git Push
 

--- a/docs/upstream-import-policy.md
+++ b/docs/upstream-import-policy.md
@@ -1,8 +1,12 @@
-# Upstream Import And Local Runtime Policy
+# Upstream Import And Runtime Policy
 
 Every Code owns its product direction, defaults, releases, and UX. `main` is the
 canonical product branch and GitHub default branch for the local `code` command on
 this machine.
+
+This document replaces the old local overlay framing. Every Code now owns
+`main`; upstream imports are synchronization work into the product branch, not a
+long-running feature branch overlay.
 
 ## Naming Ledger
 
@@ -30,8 +34,8 @@ The pre-cutover `origin/main` history was archived at
 Code product branch. Treat `local/cbusillo-overlay` as a retired branch name;
 do not revive it for new work.
 
-Treat `codex-rs/` as a read-only mirror of `openai/codex`; put editable Rust
-changes under `code-rs/`.
+Treat `codex-rs/` as a read-only local mirror of `openai/codex:main`; put
+editable Rust changes under `code-rs/`.
 
 Remote map:
 
@@ -41,6 +45,11 @@ Remote map:
 - `openai`: remote for `openai/codex`, the original/direct upstream and
   provenance source. Use it for direct upstream intake when intentional; do not
   push Every Code changes there.
+
+Do not describe either import source as the permanent primary upstream. The
+current import path may vary by task; the durable distinction is that
+`just-every/code` is a fork upstream/import source and `openai/codex` is the
+original/direct upstream and provenance source.
 
 ## Every Code-Owned Surfaces
 
@@ -67,10 +76,10 @@ Use the import helper from a clean `main` branch:
 just local-upstream-import
 ```
 
-After conflicts are resolved, preserve upstream fixes unless they contradict an
-Every Code-owned behavior above. During conflict resolution, prefer upstream
-unless the conflict touches one of those owned areas. Keep
-`scripts/local/overlay-picks.txt` empty unless a patch intentionally lives
+After conflicts are resolved, preserve imported fixes unless they contradict an
+Every Code-owned behavior above. During conflict resolution, prefer the import
+source unless the conflict touches one of those owned areas. Keep
+`scripts/local/upstream-picks.txt` empty unless a patch intentionally lives
 outside the product branch and must be replayed.
 
 ## Release Cadence

--- a/justfile
+++ b/justfile
@@ -73,11 +73,7 @@ local-remove-homebrew-code-link:
 
 [no-cd]
 local-upstream-import:
-    ./scripts/local/update-overlay-from-upstream.sh
-
-[no-cd]
-local-overlay-update:
-    ./scripts/local/update-overlay-from-upstream.sh
+    ./scripts/local/update-from-upstream.sh
 
 [no-cd]
 local-product-health:

--- a/scripts/local/fork-health.sh
+++ b/scripts/local/fork-health.sh
@@ -31,7 +31,7 @@ echo
 
 if git rev-parse --verify --quiet "$upstream_ref" >/dev/null; then
 	echo "fork delta vs $upstream_ref:"
-	git diff --shortstat "$upstream_ref"..HEAD -- code-rs scripts/local .github/workflows/release.yml docs/local-overlay.md || true
+	git diff --shortstat "$upstream_ref"..HEAD -- code-rs scripts/local .github/workflows/release.yml docs/upstream-import-policy.md || true
 	echo
 	echo "hotspot files:"
 	git diff --name-only "$upstream_ref"..HEAD -- \
@@ -42,7 +42,7 @@ if git rev-parse --verify --quiet "$upstream_ref" >/dev/null; then
 		code-rs/common/src/model_presets.rs \
 		.github/workflows/release.yml \
 		scripts/local \
-		docs/local-overlay.md || true
+		docs/upstream-import-policy.md || true
 else
 	echo "warning: upstream ref '$upstream_ref' is not available" >&2
 fi

--- a/scripts/local/update-from-upstream.sh
+++ b/scripts/local/update-from-upstream.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
-manifest="$repo_root/scripts/local/overlay-picks.txt"
+manifest="$repo_root/scripts/local/upstream-picks.txt"
 
 branch="$(git symbolic-ref --quiet --short HEAD || true)"
 if [[ -z "$branch" ]]; then

--- a/scripts/local/upstream-picks.txt
+++ b/scripts/local/upstream-picks.txt
@@ -7,7 +7,7 @@
 # - Commits already present on the product branch survive future upstream
 #   imports automatically; do not list them again here.
 # - Commit new product fixes onto the product branch first.
-# - Add a SHA here only if the fix intentionally lives outside the overlay
+# - Add a SHA here only if the fix intentionally lives outside the product
 #   branch and should be auto-replayed during future `just local-upstream-import`
 #   runs.
 # - If an old carried fix stops cherry-picking cleanly, keep it commented out,


### PR DESCRIPTION
## Summary
- rename stale `docs/local-overlay.md` to `docs/upstream-import-policy.md` and update repo metadata/routing references
- clarify that Every Code owns `main` and imports from upstream sources rather than living as a local overlay branch
- rename local upstream import helper/manifest away from overlay terminology while preserving `just local-upstream-import`

## Validation
- `rg -n "docs/local-overlay\.md|local-overlay\.md|upstreamImportPolicy" AGENTS.md README.md docs .github scripts justfile`
- `rg -n "update-overlay-from-upstream|overlay-picks|local-overlay-update|local-overlay|docs/local-overlay|local overlay|overlay branch|outside the overlay" AGENTS.md docs scripts justfile .github/github.json`
- `git diff --check`
- `./build-fast.sh`

Refs #179
Refs #184