### PR TITLE
chore(metadata): move cleanup commands to cleanup metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -28,8 +28,6 @@
     },
     "scripts": {
       "waitForGitHubRun": "scripts/wait-for-gh-run.sh --workflow Release --branch main",
-      "cleanupSpace": "just local-cleanup-space --apply --keep-current-fast-cache",
-      "cleanupSpaceCold": "just local-cleanup-space --apply",
       "upstreamImport": "just local-upstream-import"
     },
     "docsRequiredWhen": [
@@ -87,7 +85,21 @@
   },
   "cleanup": {
     "deleteMergedLocalBranches": true,
-    "removeMergedCleanWorktrees": true
+    "removeMergedCleanWorktrees": true,
+    "commands": [
+      {
+        "name": "routine warm-cache cleanup",
+        "command": "just local-cleanup-space --apply --keep-current-fast-cache",
+        "when": "routine",
+        "description": "Remove stale repo-local build caches while preserving the current fast-build cache."
+      },
+      {
+        "name": "cold cleanup",
+        "command": "just local-cleanup-space --apply",
+        "when": "cold",
+        "description": "Aggressively remove rebuildable target and cache artifacts; run only when explicitly requested."
+      }
+    ]
   },
   "metadataFreshness": {
     "updateWhen": [


### PR DESCRIPTION
## Summary

- move repo closeout cleanup metadata from `qualityGate.scripts` into `cleanup.commands`
- mark the warm-cache cleanup as routine closeout evidence
- keep the cold cleanup command as explicit/report-only metadata with `when: "cold"`

Closes #188

## Verification

- `jq empty .github/github.json`
- `/Users/cbusillo/Developer/codex-skills/github/scripts/github-repo-snapshot.sh --json | jq -e '.cleanup.status == "configured" and (.cleanup.routineCommands | length) == 1 and .cleanup.routineCommands[0].command == "just local-cleanup-space --apply --keep-current-fast-cache" and (.cleanup.commands | length) == 2'`
- `./build-fast.sh`

## Notes

- JetBrains closeout was attempted for changed files, but the inspection API returned HTTP 500 before producing findings.
