### PR TITLE
Refresh ChatGPT auth before expiry

### DIFF
--- a/code-rs/core/src/auth.rs
+++ b/code-rs/core/src/auth.rs
@@ -356,7 +356,9 @@ fn should_proactively_refresh_auth(
     if let Some(access_token) = access_token
         && let Ok(Some(expires_at)) = parse_jwt_expiration(access_token)
     {
-        return expires_at <= Utc::now();
+        return expires_at
+            <= Utc::now()
+                + chrono::Duration::minutes(CHATGPT_ACCESS_TOKEN_REFRESH_WINDOW_MINUTES);
     }
 
     last_refresh.is_some_and(|last_refresh| {
@@ -486,7 +488,11 @@ pub async fn auth_for_stored_account(
             let now = Utc::now();
             let refresh_needed = if account.mode == AuthMode::ChatGPT {
                 if let Ok(Some(expires_at)) = parse_jwt_expiration(&tokens.access_token) {
-                    expires_at <= now
+                    expires_at
+                        <= now
+                            + chrono::Duration::minutes(
+                                CHATGPT_ACCESS_TOKEN_REFRESH_WINDOW_MINUTES,
+                            )
                 } else {
                     last_refresh
                         .map(|last| last < now - chrono::Duration::days(28))
@@ -975,6 +981,7 @@ pub struct AuthDotJson {
 
 // Shared constant for token refresh (client id used for oauth token refresh flow)
 pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CHATGPT_ACCESS_TOKEN_REFRESH_WINDOW_MINUTES: i64 = 5;
 
 use std::sync::RwLock;
 
@@ -1370,12 +1377,15 @@ mod tests {
         let fresh = Utc::now() - chrono::Duration::days(1);
         let stale = Utc::now() - chrono::Duration::days(29);
         let future_access = build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() + 3600 }));
+        let expiring_access =
+            build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() + 240 }));
         let expired_access = build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() - 60 }));
 
         assert!(!should_proactively_refresh_auth(Some(fresh), None));
         assert!(should_proactively_refresh_auth(Some(stale), None));
         assert!(!should_proactively_refresh_auth(None, None));
         assert!(!should_proactively_refresh_auth(Some(stale), Some(&future_access)));
+        assert!(should_proactively_refresh_auth(Some(fresh), Some(&expiring_access)));
         assert!(should_proactively_refresh_auth(Some(fresh), Some(&expired_access)));
     }
 

--- a/code-rs/login/src/server.rs
+++ b/code-rs/login/src/server.rs
@@ -327,7 +327,7 @@ fn build_authorize_url(
         ("code_challenge", &pkce.code_challenge),
         ("code_challenge_method", "S256"),
         ("id_token_add_organizations", "true"),
-        ("code_cli_simplified_flow", "true"),
+        ("codex_cli_simplified_flow", "true"),
         ("state", state),
         ("originator", originator),
     ];
@@ -621,4 +621,38 @@ pub(crate) async fn obtain_api_key(
     }
     let body: ExchangeResp = resp.json().await.map_err(io::Error::other)?;
     Ok(body.access_token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_uses_codex_simplified_flow_parameter() {
+        let pkce = PkceCodes {
+            code_verifier: "verifier".to_string(),
+            code_challenge: "challenge".to_string(),
+        };
+        let auth_url = build_authorize_url(
+            "https://auth.openai.com",
+            "client",
+            "http://localhost:1455/auth/callback",
+            &pkce,
+            "state",
+            "code_cli_rs",
+        );
+        let parsed = url::Url::parse(&auth_url).expect("valid auth url");
+        let params = parsed.query_pairs().collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(
+            params
+                .get("codex_cli_simplified_flow")
+                .map(|value| value.as_ref()),
+            Some("true")
+        );
+        assert!(
+            !params.contains_key("code_cli_simplified_flow"),
+            "OpenAI auth rejects the fork-local parameter name as unknown"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- refresh ChatGPT access tokens inside a small pre-expiry window instead of waiting until they are already expired
- use the OpenAI auth backend's accepted `codex_cli_simplified_flow` parameter for login
- add focused regressions for both behaviors

## Upstream
- imports/adapts `15d85ea3ca` from `just-every/code`
- imports the login auth parameter part of `76937a5ba3` from `just-every/code`

## Validation
- cargo test -p code-core proactive_refresh_only_triggers_for_stale_chatgpt_auth
- cargo test -p code-login authorize_url_uses_codex_simplified_flow_parameter
- ./build-fast.sh