### PR TITLE
chore(models): update Claude Opus selector to 4.8

### DIFF
--- a/code-rs/core/src/agent_defaults.rs
+++ b/code-rs/core/src/agent_defaults.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_AGENT_NAMES: &[&str] = &[
     // Frontline for moderate/challenging tasks
     "code-gpt-5.5",
     "code-gpt-5.4",
-    "claude-opus-4.6",
+    "claude-opus-4.8",
     "antigravity",
     // Straightforward / cost-aware
     "code-gpt-5.4-mini",
@@ -160,15 +160,20 @@ const AGENT_MODEL_SPECS: &[AgentModelSpec] = &[
         pro_only: false,
     },
     AgentModelSpec {
-        slug: "claude-opus-4.6",
+        slug: "claude-opus-4.8",
         family: "claude",
         cli: "claude",
         read_only_args: CLAUDE_OPUS_READ_ONLY,
         write_args: CLAUDE_OPUS_WRITE,
-        model_args: &["--model", "claude-opus-4-6"],
+        model_args: &["--model", "claude-opus-4-8"],
         description: "Higher-capacity Claude model for complex reasoning; use when you want the strongest Claude.",
         enabled_by_default: true,
-        aliases: &["claude-opus", "claude-opus-4.1", "claude-opus-4.5"],
+        aliases: &[
+            "claude-opus",
+            "claude-opus-4.1",
+            "claude-opus-4.5",
+            "claude-opus-4.6",
+        ],
         gating_env: None,
         is_frontline: true,
         pro_only: false,
@@ -681,6 +686,16 @@ mod tests {
         assert!(agent_model_spec("code-gpt-5.2-codex").is_none());
         assert!(agent_model_spec("gpt-5.3-codex-spark").is_none());
         assert!(agent_model_spec("code-gpt-5.2").is_none());
+    }
+
+    #[test]
+    fn claude_opus_aliases_resolve_to_current_opus() {
+        let opus = agent_model_spec("claude-opus").expect("opus alias present");
+        assert_eq!(opus.slug, "claude-opus-4.8");
+        assert_eq!(opus.model_args, &["--model", "claude-opus-4-8"]);
+
+        let legacy = agent_model_spec("claude-opus-4.6").expect("legacy opus alias present");
+        assert_eq!(legacy.slug, "claude-opus-4.8");
     }
 
     #[test]

--- a/code-rs/core/src/codex/streaming.rs
+++ b/code-rs/core/src/codex/streaming.rs
@@ -7999,7 +7999,7 @@ mod resolve_agent_command_for_check_tests {
 
     #[test]
     fn external_models_use_cli_for_command_checks() {
-        let (cmd, is_builtin) = resolve_agent_command_for_check("claude-opus-4.6", None);
+        let (cmd, is_builtin) = resolve_agent_command_for_check("claude-opus-4.8", None);
         assert_eq!(cmd, "claude");
         assert!(!is_builtin, "Claude should not be treated as a built-in family");
     }

--- a/code-rs/core/src/config.rs
+++ b/code-rs/core/src/config.rs
@@ -3479,7 +3479,7 @@ model_verbosity = "high"
         let mut cfg = ConfigToml::default();
         cfg.agents = vec![
             AgentConfig {
-                name: "claude-sonnet-4.5".to_string(),
+                name: "claude-opus-4.6".to_string(),
                 command: "claude".to_string(),
                 args: Vec::new(),
                 read_only: false,
@@ -3518,7 +3518,7 @@ model_verbosity = "high"
 
         upgrade_legacy_model_slugs(&mut cfg);
 
-        assert_eq!(cfg.agents[0].name, "claude-sonnet-4.6");
+        assert_eq!(cfg.agents[0].name, "claude-opus-4.8");
         assert_eq!(cfg.agents[1].name, "antigravity");
         assert_eq!(cfg.agents[1].command, "agy");
         assert_eq!(cfg.agents[2].name, "qwen3-coder-plus");
@@ -3533,7 +3533,7 @@ model_verbosity = "high"
                 name: "code".to_string(),
                 read_only: false,
                 agents: vec![
-                    "claude-sonnet-4.5".to_string(),
+                    "claude-opus-4.6".to_string(),
                     "gemini-3-flash".to_string(),
                     "qwen-3-coder".to_string(),
                 ],
@@ -3552,7 +3552,7 @@ model_verbosity = "high"
         assert_eq!(
             command.agents,
             vec![
-                "claude-sonnet-4.6".to_string(),
+                "claude-opus-4.8".to_string(),
                 "antigravity".to_string(),
                 "qwen3-coder-plus".to_string(),
             ]
@@ -3673,6 +3673,7 @@ model_verbosity = "high"
 
         assert!(enabled_names.contains("code-gpt-5.5"));
         assert!(enabled_names.contains("code-gpt-5.4"));
+        assert!(enabled_names.contains("claude-opus-4.8"));
         assert!(enabled_names.contains("claude-sonnet-4.6"));
         assert!(enabled_names.contains("antigravity"));
         assert!(enabled_names.contains("qwen3-coder-plus"));

--- a/code-rs/core/src/config/validation.rs
+++ b/code-rs/core/src/config/validation.rs
@@ -229,10 +229,12 @@ fn upgrade_legacy_model_slug(slug: &str) -> Option<String> {
         return Some(format!("gpt-5.1-codex{rest}"));
     }
 
-    // Upgrade Anthropic Opus 4.1/4.5 to 4.6
-    if slug.eq_ignore_ascii_case("claude-opus-4.1") || slug.eq_ignore_ascii_case("claude-opus-4.5")
+    // Upgrade older Anthropic Opus selectors to the current Opus line.
+    if slug.eq_ignore_ascii_case("claude-opus-4.1")
+        || slug.eq_ignore_ascii_case("claude-opus-4.5")
+        || slug.eq_ignore_ascii_case("claude-opus-4.6")
     {
-        return Some("claude-opus-4.6".to_string());
+        return Some("claude-opus-4.8".to_string());
     }
 
     // Upgrade Anthropic Sonnet 4.5 to 4.6.

--- a/code-rs/tui/tests/vt100_chatwidget_snapshot.rs
+++ b/code-rs/tui/tests/vt100_chatwidget_snapshot.rs
@@ -2574,7 +2574,7 @@ fn agents_toggle_claude_opus_persists_via_slash_command() {
     let overlay_initial = normalize_output(render_chat_widget_to_vt100(&mut harness, 100, 28));
     assert!(overlay_initial.contains("Agents"), "Agents overlay did not open");
 
-    harness.show_agent_editor("claude-opus-4.6");
+    harness.show_agent_editor("claude-opus-4.8");
 
     let editor_frame = normalize_output(render_chat_widget_to_vt100(&mut harness, 100, 28));
     let editor_lower = editor_frame.to_lowercase();
@@ -2593,7 +2593,7 @@ fn agents_toggle_claude_opus_persists_via_slash_command() {
 
     let overview_after_save = normalize_output(render_chat_widget_to_vt100(&mut harness, 100, 28));
     let overview_lower = overview_after_save.to_lowercase();
-    assert!(overview_lower.contains("claude-opus-4.6"));
+    assert!(overview_lower.contains("claude-opus-4.8"));
     assert!(overview_lower.contains("disabled"));
 
     harness.send_key(make_key(KeyCode::Esc, KeyModifiers::NONE));
@@ -2603,7 +2603,7 @@ fn agents_toggle_claude_opus_persists_via_slash_command() {
     harness.send_key(make_key(KeyCode::Down, KeyModifiers::NONE));
     let overlay_reopen = normalize_output(render_chat_widget_to_vt100(&mut harness, 100, 28));
     let reopen_lower = overlay_reopen.to_lowercase();
-    assert!(reopen_lower.contains("claude-opus-4.6"));
+    assert!(reopen_lower.contains("claude-opus-4.8"));
     assert!(reopen_lower.contains("disabled"));
 }
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -19,7 +19,7 @@ instructions = "Preamble added to this agent’s prompt"
 Field recap: `name` (slug/alias), `command` (absolute paths ok), `args*` (RO/RW lists override base), `env`, `read_only`, `enabled`, optional `description` and `instructions`.
 
 ### Built-in defaults
-If no `[[agents]]` are configured, Every Code advertises built-in agent/model selectors (gated by env `CODE_ENABLE_CLOUD_AGENT_MODEL` for cloud variants): `code-gpt-5.5`, `code-gpt-5.4`, `code-gpt-5.4-mini`, `claude-opus-4.6`, `antigravity`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `qwen3-coder-plus`, `cloud-gpt-5.1-codex-max`. Built-ins strip any user `--model/-m` flags to avoid conflicts and inject their own when the target CLI supports model flags.
+If no `[[agents]]` are configured, Every Code advertises built-in agent/model selectors (gated by env `CODE_ENABLE_CLOUD_AGENT_MODEL` for cloud variants): `code-gpt-5.5`, `code-gpt-5.4`, `code-gpt-5.4-mini`, `claude-opus-4.8`, `antigravity`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `qwen3-coder-plus`, `cloud-gpt-5.1-codex-max`. Built-ins strip any user `--model/-m` flags to avoid conflicts and inject their own when the target CLI supports model flags.
 
 Tip: `antigravity` uses Google's Antigravity CLI (`agy`) as the Google-agent path. Consumer Gemini CLI is no longer a built-in default; configure it manually only when you intentionally rely on enterprise/API-key Gemini CLI access.
 
@@ -28,7 +28,7 @@ Tip: `antigravity` uses Google's Antigravity CLI (`agy`) as the Google-agent pat
 [[subagents.commands]]
 name = "plan"                     # slash name (/plan, /solve, /code, or custom)
 read_only = true                  # default plan/solve=true, code=false
-agents = ["code-gpt-5.4", "claude-opus-4.6"]  # falls back to enabled agents or built-ins
+agents = ["code-gpt-5.4", "claude-opus-4.8"]  # falls back to enabled agents or built-ins
 orchestrator_instructions = "Guidance for the Every Code agent before spawning agents"
 agent_instructions = "Preamble added to each spawned agent"
 ```
@@ -84,7 +84,7 @@ enabled = true
 [[subagents.commands]]
 name = "context"
 read_only = true
-agents = ["code-gpt-5.4", "claude-opus-4.6"]
+agents = ["code-gpt-5.4", "claude-opus-4.8"]
 orchestrator_instructions = "Have each agent summarize the most relevant files and tests."
 agent_instructions = "Return paths plus 1–2 sentence rationale; do not edit files."
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -73,7 +73,7 @@ env_key = "MISTRAL_API_KEY"
 Or a proxy that converts OpenAI-compatible requests to another vendor (e.g., Anthropic or Gemini):
 
 ```toml
-model = "claude-opus-4.6"
+model = "claude-opus-4.8"
 model_provider = "claude-proxy"
 
 [model_providers.claude-proxy]
@@ -473,7 +473,7 @@ tool_timeout_sec = 30
 
 Sub-agents are orchestrated helper workflows you can trigger with slash commands (for example `/plan`, `/solve`, `/code`). Each entry under `[[subagents.commands]]` defines the slash command name, whether spawned agents run in read-only mode, which `agents` to launch, and extra guidance for both the orchestrator (Code) and the individual agents.
 
-By default (when no `[[agents]]` are configured) Code advertises these agent/model selectors for multi-agent runs: `code-gpt-5.5`, `code-gpt-5.4`, `code-gpt-5.4-mini`, `claude-opus-4.6`, `antigravity`, `claude-sonnet-4.6`, `claude-haiku-4.5`, and `qwen3-coder-plus`. The cloud counterpart, `cloud-gpt-5.1-codex-max`, only appears when `CODE_ENABLE_CLOUD_AGENT_MODEL=1` is set. You can override the list by defining `[[agents]]` entries or by specifying `agents = [ … ]` on a given `[[subagents.commands]]` entry. Consumer Gemini CLI is not a built-in default; add a custom `[[agents]]` block only when you intentionally rely on enterprise/API-key Gemini CLI access.
+By default (when no `[[agents]]` are configured) Code advertises these agent/model selectors for multi-agent runs: `code-gpt-5.5`, `code-gpt-5.4`, `code-gpt-5.4-mini`, `claude-opus-4.8`, `antigravity`, `claude-sonnet-4.6`, `claude-haiku-4.5`, and `qwen3-coder-plus`. The cloud counterpart, `cloud-gpt-5.1-codex-max`, only appears when `CODE_ENABLE_CLOUD_AGENT_MODEL=1` is set. You can override the list by defining `[[agents]]` entries or by specifying `agents = [ … ]` on a given `[[subagents.commands]]` entry. Consumer Gemini CLI is not a built-in default; add a custom `[[agents]]` block only when you intentionally rely on enterprise/API-key Gemini CLI access.
 
 ```toml
 [[subagents.commands]]

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -120,7 +120,7 @@ Implementation Notes
   `code-rs/core/src/slash_commands.rs`.
   When no `[[agents]]` are configured, the orchestrator advertises the
   following agent/model selectors to the LLM for multi-agent runs: `code-gpt-5.5`,
-  `code-gpt-5.4`, `claude-opus-4.6`,
+  `code-gpt-5.4`, `claude-opus-4.8`,
   `antigravity`, `code-gpt-5.4-mini`, `claude-sonnet-4.6`,
   `claude-haiku-4.5`, and `qwen3-coder-plus` (with `cloud-gpt-5.1-codex-max`
   gated by `CODE_ENABLE_CLOUD_AGENT_MODEL`). You can replace or pin this set via


### PR DESCRIPTION
## Summary
- update the built-in Claude Opus agent selector to `claude-opus-4.8`
- launch Claude Code with `--model claude-opus-4-8`
- keep older Opus selector names as compatibility aliases and config-upgrade inputs
- refresh docs and regression assertions that surface the built-in selector list

Refs #177

## Validation
- `./build-fast.sh`
- JetBrains inspection closeout, scope `changed_files`: clean
