### PR TITLE
Fix auth fallback and shutdown completions

### DIFF
--- a/code-rs/core/src/auth.rs
+++ b/code-rs/core/src/auth.rs
@@ -205,20 +205,30 @@ impl CodexAuth {
                         .as_ref()
                         .map(|tokens| tokens.access_token.as_str()),
                 ) {
-                    tokio::time::timeout(Duration::from_secs(60), self.refresh_token())
-                        .await
-                        .map_err(|_| {
-                            std::io::Error::other(
-                                "timed out while refreshing OpenAI API key",
-                            )
-                        })?
-                        .map_err(std::io::Error::other)?;
+                    let refresh_result = tokio::time::timeout(
+                        Duration::from_secs(60),
+                        self.refresh_token(),
+                    )
+                    .await
+                    .map_err(|_| {
+                        std::io::Error::other("timed out while refreshing OpenAI API key")
+                    })
+                    .and_then(|result| result.map_err(std::io::Error::other));
 
-                    tokens = self
-                        .get_current_token_data()
-                        .ok_or(std::io::Error::other(
-                            "Token data is not available after refresh.",
-                        ))?;
+                    match refresh_result {
+                        Ok(_) => {
+                            tokens = self
+                                .get_current_token_data()
+                                .ok_or(std::io::Error::other(
+                                    "Token data is not available after refresh.",
+                                ))?;
+                        }
+                        Err(err) => {
+                            if !access_token_is_still_valid(&tokens.access_token, Utc::now()) {
+                                return Err(err);
+                            }
+                        }
+                    }
                 }
 
                 Ok(tokens)
@@ -366,6 +376,13 @@ fn should_proactively_refresh_auth(
     })
 }
 
+fn access_token_is_still_valid(access_token: &str, now: DateTime<Utc>) -> bool {
+    parse_jwt_expiration(access_token)
+        .ok()
+        .flatten()
+        .is_some_and(|expires_at| expires_at > now)
+}
+
 pub const OPENAI_API_KEY_ENV_VAR: &str = "OPENAI_API_KEY";
 pub const CODEX_API_KEY_ENV_VAR: &str = "CODEX_API_KEY";
 
@@ -511,7 +528,22 @@ pub async fn auth_for_stored_account(
                 .await
                 .map_err(|_| {
                     std::io::Error::other("timed out while refreshing OpenAI API key")
-                })?;
+                });
+
+                let refresh_response = match refresh_response {
+                    Ok(response) => response,
+                    Err(err) => {
+                        if access_token_is_still_valid(&tokens.access_token, Utc::now()) {
+                            return Ok(CodexAuth::from_tokens_with_originator_and_mode(
+                                tokens,
+                                last_refresh,
+                                originator,
+                                account.mode,
+                            ));
+                        }
+                        return Err(err);
+                    }
+                };
 
                 let refresh_response = match refresh_response {
                     Ok(response) => response,
@@ -529,6 +561,14 @@ pub async fn auth_for_stored_account(
                                     ));
                                 }
                             }
+                        }
+                        if access_token_is_still_valid(&tokens.access_token, Utc::now()) {
+                            return Ok(CodexAuth::from_tokens_with_originator_and_mode(
+                                tokens,
+                                last_refresh,
+                                originator,
+                                account.mode,
+                            ));
                         }
                         return Err(std::io::Error::other(err));
                     }
@@ -1017,9 +1057,14 @@ mod tests {
     use base64::Engine;
     use reqwest::StatusCode;
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
     use serde::Serialize;
     use serde_json::json;
     use tempfile::tempdir;
+    use wiremock::matchers::method;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
 
     const LAST_REFRESH: &str = "2025-08-06T20:41:36.232376Z";
 
@@ -1389,6 +1434,82 @@ mod tests {
         assert!(should_proactively_refresh_auth(Some(fresh), Some(&expired_access)));
     }
 
+    #[test]
+    fn access_token_validity_uses_jwt_expiration() {
+        let future_access = build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() + 3600 }));
+        let expired_access = build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() - 60 }));
+
+        assert!(access_token_is_still_valid(&future_access, Utc::now()));
+        assert!(!access_token_is_still_valid(&expired_access, Utc::now()));
+        assert!(!access_token_is_still_valid("not-a-jwt", Utc::now()));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn auth_for_stored_account_uses_valid_cached_token_if_proactive_refresh_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let _guard = EnvVarGuard::set(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR, server.uri());
+        let code_home = tempdir().unwrap();
+        let access_token = build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() + 240 }));
+        let account = stored_chatgpt_account(access_token.clone());
+
+        let auth = auth_for_stored_account(code_home.path(), &account, "test")
+            .await
+            .expect("valid cached token should survive proactive refresh failure");
+
+        assert_eq!(auth.get_token().await.unwrap(), access_token);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn token_data_uses_valid_cached_token_if_proactive_refresh_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let _guard = EnvVarGuard::set(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR, server.uri());
+        let access_token = build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() + 240 }));
+        let tokens = token_data_for_access(access_token.clone());
+        let auth = CodexAuth::from_tokens_with_originator_and_mode(
+            tokens,
+            Some(Utc::now()),
+            "test",
+            AuthMode::ChatGPT,
+        );
+
+        let token_data = auth
+            .get_token_data()
+            .await
+            .expect("valid cached token should survive proactive refresh failure");
+
+        assert_eq!(token_data.access_token, access_token);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn auth_for_stored_account_errors_if_expired_token_refresh_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let _guard = EnvVarGuard::set(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR, server.uri());
+        let code_home = tempdir().unwrap();
+        let access_token = build_jwt(serde_json::json!({ "exp": Utc::now().timestamp() - 60 }));
+        let account = stored_chatgpt_account(access_token);
+
+        let err = auth_for_stored_account(code_home.path(), &account, "test")
+            .await
+            .expect_err("expired token should still require successful refresh");
+
+        assert!(err.to_string().contains("temporarily unavailable"));
+    }
+
     #[tokio::test]
     async fn auth_manager_skips_refresh_for_api_key_auth() {
         let manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("sk-test"));
@@ -1432,6 +1553,50 @@ mod tests {
         let payload_b64 = b64(&serde_json::to_vec(&payload).unwrap());
         let signature_b64 = b64(b"sig");
         format!("{header_b64}.{payload_b64}.{signature_b64}")
+    }
+
+    fn stored_chatgpt_account(access_token: String) -> crate::auth_accounts::StoredAccount {
+        crate::auth_accounts::StoredAccount {
+            id: "account-id".to_string(),
+            mode: AuthMode::ChatGPT,
+            label: None,
+            openai_api_key: None,
+            tokens: Some(token_data_for_access(access_token)),
+            last_refresh: Some(Utc::now()),
+            created_at: None,
+            last_used_at: None,
+        }
+    }
+
+    fn token_data_for_access(access_token: String) -> TokenData {
+        TokenData {
+            id_token: IdTokenInfo::default(),
+            access_token,
+            refresh_token: "refresh-token".to_string(),
+            account_id: Some("account-id".to_string()),
+        }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: String) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
     }
 
     fn write_auth_file(params: AuthFileParams, code_home: &Path) -> std::io::Result<String> {

--- a/code-rs/core/src/codex/session.rs
+++ b/code-rs/core/src/codex/session.rs
@@ -161,6 +161,7 @@ pub(super) struct State {
     pub(super) pending_manual_compacts: VecDeque<String>,
     pub(super) wait_interrupt_epoch: u64,
     pub(super) wait_interrupt_reason: Option<WaitInterruptReason>,
+    pub(super) shutting_down: bool,
     pub(super) context_timeline: ContextTimeline,
     pub(super) environment_context_tracker: EnvironmentContextTracker,
     pub(super) environment_context_seq: u64,
@@ -1304,9 +1305,21 @@ impl Session {
     /// scheduled immediately.
     pub fn enqueue_out_of_turn_item(&self, item: ResponseInputItem) -> bool {
         let mut state = self.state.lock().unwrap();
+        if state.shutting_down {
+            return false;
+        }
         let should_start_turn = state.current_task.is_none();
         state.pending_input.push(item);
         should_start_turn
+    }
+
+    pub(super) fn mark_shutting_down(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.shutting_down = true;
+    }
+
+    pub(super) fn is_shutting_down(&self) -> bool {
+        self.state.lock().unwrap().shutting_down
     }
 
     pub(crate) fn next_internal_sub_id(&self) -> String {

--- a/code-rs/core/src/codex/streaming.rs
+++ b/code-rs/core/src/codex/streaming.rs
@@ -639,6 +639,7 @@ pub(super) async fn submission_loop(
                 // abort any current running session and clone its state
                 let old_session = sess.take();
                 let state = if let Some(sess_arc) = old_session.as_ref() {
+                    sess_arc.mark_shutting_down();
                     sess_arc.notify_wait_interrupted(WaitInterruptReason::SessionAborted);
                     sess_arc.abort();
                     sess_arc.state.lock().unwrap().partial_clone()
@@ -1400,6 +1401,7 @@ pub(super) async fn submission_loop(
 
                 // Ensure any running agent is aborted so streaming stops promptly.
                 if let Some(sess_arc) = sess.as_ref() {
+                    sess_arc.mark_shutting_down();
                     let s2 = sess_arc.clone();
                     tokio::spawn(async move {
                         s2.notify_wait_interrupted(WaitInterruptReason::SessionAborted);
@@ -10684,7 +10686,7 @@ async fn handle_container_exec_with_params(
         );
     }
 
-    let sess_for_hooks = sess.self_handle.upgrade();
+    let sess_for_hooks = sess.self_handle.clone();
     let params_for_after_hooks = params_for_hooks.clone();
     let exec_ctx_for_hooks = exec_command_context.clone();
     let exec_ctx_for_task = exec_command_context.clone();
@@ -10725,7 +10727,7 @@ async fn handle_container_exec_with_params(
     let suppress_event_flag_task = suppress_event_flag.clone();
     let display_label_task = display_label.clone();
     let tool_output_max_bytes = sess.tool_output_max_bytes;
-    let sess_for_background_completion = sess.self_handle.upgrade();
+    let sess_for_background_completion = sess.self_handle.clone();
     let task_handle = tokio::spawn(async move {
         // Build stdout stream with tail capture. We cannot stamp via `Session` here,
         // but deltas will be delivered with neutral ordering which the UI tolerates.
@@ -10782,8 +10784,12 @@ async fn handle_container_exec_with_params(
             exit_code,
             duration: out.duration,
         });
-        let ev = Event { id: sub_id_for_events.clone(), event_seq: 0, msg: end_msg, order: Some(order_meta_for_end) };
-        let _ = tx_event.send(ev).await;
+        if let Some(sess_arc) = sess_for_background_completion.upgrade()
+            && !sess_arc.is_shutting_down()
+        {
+            let ev = Event { id: sub_id_for_events.clone(), event_seq: 0, msg: end_msg, order: Some(order_meta_for_end) };
+            let _ = tx_event.send(ev).await;
+        }
 
         // Store result for waiters
         {
@@ -10792,7 +10798,7 @@ async fn handle_container_exec_with_params(
         }
 
         if backgrounded_task.load(std::sync::atomic::Ordering::Relaxed) {
-            if let Some(sess_arc) = sess_for_hooks.clone() {
+            if let Some(sess_arc) = sess_for_hooks.upgrade() {
                 let mut hook_tracker = TurnDiffTracker::new();
                 sess_arc
                     .run_hooks_for_exec_event(
@@ -10816,7 +10822,12 @@ async fn handle_container_exec_with_params(
                     format!("{label} completed in background")
                 };
                 let bg_event = EventMsg::BackgroundEvent(BackgroundEventEvent { message });
-                if let Some(sess_arc) = sess_for_background_completion.as_ref() {
+                if let Some(sess_arc) = sess_for_background_completion.upgrade() {
+                    if sess_arc.is_shutting_down() {
+                        if let Some(n) = ANY_BG_NOTIFY.get() { n.notify_waiters(); }
+                        notify_task.notify_waiters();
+                        return;
+                    }
                     let ev = sess_arc.make_event(&sub_id_for_events, bg_event);
                     sess_arc.send_event(ev).await;
 
@@ -10847,7 +10858,7 @@ async fn handle_container_exec_with_params(
                             text: PENDING_ONLY_SENTINEL.to_string(),
                         }];
                         let agent = AgentTask::spawn(
-                            Arc::clone(sess_arc),
+                            Arc::clone(&sess_arc),
                             turn_context,
                             sub_id,
                             sentinel_input,
@@ -10856,9 +10867,6 @@ async fn handle_container_exec_with_params(
                         );
                         sess_arc.set_task(agent);
                     }
-                } else {
-                    let ev = Event { id: sub_id_for_events.clone(), event_seq: 0, msg: bg_event, order: None };
-                    let _ = tx_event.send(ev).await;
                 }
             }
             if let Some(n) = ANY_BG_NOTIFY.get() { n.notify_waiters(); }


### PR DESCRIPTION
## Summary
- fall back to cached ChatGPT access tokens when proactive refresh fails but the token is still unexpired
- keep expired tokens failing when refresh cannot complete
- mark replaced/shutting-down sessions inactive so late background completions cannot enqueue hidden follow-up turns

## Validation
- cargo test -p code-core proactive_refresh --lib
- cargo test -p code-core auth_for_stored_account --lib
- cargo test -p code-core agent_completion_wake --lib
- ./build-fast.sh