### PR TITLE
chore(release): prepare v0.6.107

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.106",
+  "version": "0.6.107",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-## @just-every/code v0.6.106
+## @just-every/code v0.6.107
 
 See CHANGELOG.md for details.

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
 ## @just-every/code v0.6.107
 
-See CHANGELOG.md for details.
+This release focuses on model freshness, session reliability, and getting the
+release path into better shape ahead of the next model drop.
+
+### Highlights
+
+- Updated the built-in Claude Opus selector to Claude Opus 4.8, including alias
+  upgrades for older Opus selector names.
+- Added regression coverage for dynamic remote GPT model discovery, so backend
+  model slugs such as a future GPT-5.6 can appear without requiring another
+  local selector release.
+- Fixed ChatGPT auth fallback behavior, shutdown completions, and token refresh
+  timing to reduce stale-auth interruptions.
+- Tightened session-scoped agent state so archived agent activity, visibility,
+  and status stay isolated across reconnects and same-repo sessions.
+- Split release metadata preparation from final publishing. Release PRs no
+  longer wait on the full preflight and platform matrix, while final publishing
+  still runs the full release gate and platform asset builds.
+- Cleaned up Every Code/CODEX compatibility docs, package shim behavior,
+  release preflight paths, and agent/skill configuration docs.


### PR DESCRIPTION
This automated release PR contains the version and release-notes changes for v0.6.107.

Note: the Release workflow could not create this PR because GitHub Actions is not permitted to create pull requests in this repo, and OPENAI_API_KEY is not configured, so release notes fell back to the minimal stub.

Merge this PR to let the protected main-branch Release workflow create the tag and GitHub Release assets from main.