### PR TITLE
chore(release): prepare v0.6.108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 - (none)
 
+## [0.6.108] - 2026-05-29
+
+- Release: require local release metadata before publishing and validate the generated notes version in CI. (cfd73d45)
+- Release: right-size local release note prompts so tiny releases can ship concise one-bullet notes. (5d6108b6, a09767e8)
+
 ## [0.6.107] - 2026-05-29
 
 - Models: update Claude Opus selector aliases to Claude Opus 4.8 and add coverage for dynamic remote GPT model discovery. (d388ac4b, 7e250da)

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.107",
+  "version": "0.6.108",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,17 +1,16 @@
-## @just-every/code v0.6.107
+## @just-every/code v0.6.108
 
-This release focuses on model freshness, session reliability, and a smoother release path.
+This release tightens the local release metadata workflow for smaller, cleaner release PRs.
 
 ### Changes
 
-- Updated the built-in Claude Opus selector to Claude Opus 4.8 and added coverage for dynamic remote GPT model discovery.
-- Fixed ChatGPT token refresh, auth fallback, and shutdown completions to reduce stale-auth interruptions.
-- Kept archived agent activity, visibility, and status isolated across reconnects and same-repo sessions.
-- Split release metadata preparation from final publishing so release PRs stay lightweight while publish runs the full gate.
-- Cleaned up Every Code/CODEX compatibility docs, package shim behavior, release preflight paths, and agent/skill configuration docs.
+- Require locally prepared release metadata before publishing, with CI validation that the generated release notes match the target version.
+- Make local release note generation scale down for tiny releases, including concise one-bullet GitHub notes when that is the clearest output.
 
 ### Install
 
 ```bash
-gh release download v0.6.107 --repo cbusillo/code
+gh release download v0.6.108 --repo cbusillo/code
 ```
+
+Compare: https://github.com/cbusillo/code/compare/v0.6.107...v0.6.108


### PR DESCRIPTION
## Summary

- bump `@just-every/code` package metadata to `0.6.108`
- add the `0.6.108` changelog entry for the local release-notes workflow changes
- update GitHub release notes for `v0.6.108`

## Validation

- `scripts/check-release-notes-version.sh --version 0.6.108`
- `git diff --check -- codex-cli/package.json CHANGELOG.md docs/release-notes/RELEASE_NOTES.md`
