### PR TITLE
fix(app-server): harden websocket transport

### DIFF
--- a/code-rs/Cargo.lock
+++ b/code-rs/Cargo.lock
@@ -911,6 +911,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "futures",
  "owo-colors",
+ "reqwest",
  "serde",
  "serde_json",
  "sha1",

--- a/code-rs/app-server/Cargo.toml
+++ b/code-rs/app-server/Cargo.toml
@@ -50,3 +50,4 @@ uuid = { workspace = true, features = ["serde", "v7"] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+reqwest = { workspace = true }

--- a/code-rs/app-server/src/transport.rs
+++ b/code-rs/app-server/src/transport.rs
@@ -31,7 +31,12 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
-use tokio_tungstenite::accept_async;
+use tokio_tungstenite::accept_hdr_async;
+use tokio_tungstenite::tungstenite::handshake::server::ErrorResponse;
+use tokio_tungstenite::tungstenite::handshake::server::Request;
+use tokio_tungstenite::tungstenite::handshake::server::Response;
+use tokio_tungstenite::tungstenite::http::StatusCode;
+use tokio_tungstenite::tungstenite::http::header::ORIGIN;
 use tokio_tungstenite::tungstenite::Message as WebSocketMessage;
 use tracing::debug;
 use tracing::error;
@@ -54,15 +59,7 @@ fn print_websocket_startup_banner(addr: SocketAddr) {
     let note_label = colorize("note:", Style::new().dimmed());
     eprintln!("{title}");
     eprintln!("  {listening_label} {listen_url}");
-    if addr.ip().is_loopback() {
-        eprintln!(
-            "  {note_label} binds localhost only (use SSH port-forwarding for remote access)"
-        );
-    } else {
-        eprintln!(
-            "  {note_label} this is a raw WS server; consider running behind TLS/auth for real remote use"
-        );
-    }
+    eprintln!("  {note_label} binds localhost only (use SSH port-forwarding for remote access)");
 }
 
 #[allow(clippy::print_stderr)]
@@ -81,6 +78,7 @@ pub enum AppServerTransport {
 pub enum AppServerTransportParseError {
     UnsupportedListenUrl(String),
     InvalidWebSocketListenUrl(String),
+    NonLoopbackWebSocketListenUrl(String),
 }
 
 impl std::fmt::Display for AppServerTransportParseError {
@@ -93,6 +91,10 @@ impl std::fmt::Display for AppServerTransportParseError {
             AppServerTransportParseError::InvalidWebSocketListenUrl(listen_url) => write!(
                 f,
                 "invalid websocket --listen URL `{listen_url}`; expected `ws://IP:PORT`"
+            ),
+            AppServerTransportParseError::NonLoopbackWebSocketListenUrl(listen_url) => write!(
+                f,
+                "unsupported websocket --listen URL `{listen_url}`; websocket app-server binds must use a loopback IP address"
             ),
         }
     }
@@ -112,6 +114,11 @@ impl AppServerTransport {
             let bind_address = socket_addr.parse::<SocketAddr>().map_err(|_| {
                 AppServerTransportParseError::InvalidWebSocketListenUrl(listen_url.to_string())
             })?;
+            if !bind_address.ip().is_loopback() {
+                return Err(AppServerTransportParseError::NonLoopbackWebSocketListenUrl(
+                    listen_url.to_string(),
+                ));
+            }
             return Ok(Self::WebSocket { bind_address });
         }
 
@@ -295,7 +302,7 @@ async fn run_websocket_connection(
     stream: TcpStream,
     transport_event_tx: mpsc::Sender<TransportEvent>,
 ) {
-    let websocket_stream = match accept_async(stream).await {
+    let websocket_stream = match accept_hdr_async(stream, reject_origin_websocket_requests).await {
         Ok(stream) => stream,
         Err(err) => {
             warn!("failed to complete websocket handshake: {err}");
@@ -386,6 +393,24 @@ async fn run_websocket_connection(
     let _ = transport_event_tx
         .send(TransportEvent::ConnectionClosed { connection_id })
         .await;
+}
+
+fn reject_origin_websocket_requests(
+    request: &Request,
+    response: Response,
+) -> Result<Response, ErrorResponse> {
+    if request.headers().contains_key(ORIGIN) {
+        warn!(
+            uri = %request.uri(),
+            "rejecting app-server websocket request with Origin header"
+        );
+        return Err(Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .body(Some("WebSocket Origin requests are not accepted".to_string()))
+            .expect("static websocket error response should build"));
+    }
+
+    Ok(response)
 }
 
 async fn forward_incoming_message(

--- a/code-rs/app-server/tests/websocket_parity.rs
+++ b/code-rs/app-server/tests/websocket_parity.rs
@@ -101,6 +101,59 @@ async fn assert_no_message(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_rejects_origin_header_handshakes() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr: SocketAddr = listener.local_addr().expect("resolve bound address");
+    drop(listener);
+
+    let server_handle = tokio::spawn(async move {
+        run_main_with_transport(
+            None,
+            CliConfigOverrides::default(),
+            AppServerTransport::WebSocket { bind_address: addr },
+        )
+        .await
+    });
+
+    let url = format!("http://{addr}/");
+    let mut attempts = 0;
+    let response = loop {
+        match reqwest::Client::new()
+            .get(&url)
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket")
+            .header("Sec-WebSocket-Version", "13")
+            .header("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .header("Origin", "http://example.test")
+            .send()
+            .await
+        {
+            Ok(response) => break response,
+            Err(err) => {
+                attempts += 1;
+                assert!(attempts < 40, "failed to reach {url}: {err}");
+                sleep(Duration::from_millis(25)).await;
+            }
+        }
+    };
+
+    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+    server_handle.abort();
+}
+
+#[test]
+fn websocket_listen_url_requires_loopback_bind() {
+    let err = AppServerTransport::from_listen_url("ws://0.0.0.0:4242")
+        .expect_err("non-loopback websocket bind should be rejected");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("loopback"),
+        "unexpected non-loopback error: {message}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn websocket_user_agent_is_connection_scoped() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
     let addr: SocketAddr = listener.local_addr().expect("resolve bound address");


### PR DESCRIPTION
## Summary
- restrict `code app-server --listen ws://...` to loopback addresses only
- reject websocket upgrade requests that include browser `Origin` headers
- add websocket regression coverage for Origin rejection and non-loopback listen URLs

## Validation
- `cargo test -p code-app-server --test websocket_parity websocket_`
- `./build-fast.sh`

Refs #225
Refs #216
