### PR TITLE
test(core): assert memory summary prompt injection

### DIFF
--- a/code-rs/core/tests/prompt_context_dedup.rs
+++ b/code-rs/core/tests/prompt_context_dedup.rs
@@ -170,7 +170,7 @@ async fn initial_session_request_injects_memory_when_summary_exists() {
     assert!(text.contains("## Memory"));
     assert!(text.contains("sentinel memory guidance for request capture"));
     assert!(text.contains(&format!(
-        "{} (already provided below; do NOT open again)",
-        memories_dir.join("memory_summary.md").display()
+        "{}/memory_summary.md (already provided below; do NOT open again)",
+        memories_dir.display()
     )));
 }

--- a/code-rs/core/tests/prompt_context_dedup.rs
+++ b/code-rs/core/tests/prompt_context_dedup.rs
@@ -112,3 +112,65 @@ async fn initial_session_request_does_not_duplicate_project_docs_or_skills() {
     assert_eq!(text.matches("### Available skills").count(), 1);
     assert_eq!(text.matches("- demo: Demo skill").count(), 1);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initial_session_request_injects_memory_when_summary_exists() {
+    let server = MockServer::start().await;
+    let request = mount_sse_once(&server, completed_sse("resp-memory")).await;
+
+    let model_provider = ModelProviderInfo {
+        base_url: Some(format!("{}/v1", server.uri())),
+        ..built_in_model_providers(None)["openai"].clone()
+    };
+
+    let cwd = TempDir::new().unwrap();
+    let code_home = TempDir::new().unwrap();
+    let memories_dir = code_home.path().join("memories");
+    std::fs::create_dir_all(&memories_dir).unwrap();
+    std::fs::write(
+        memories_dir.join("memory_summary.md"),
+        "sentinel memory guidance for request capture",
+    )
+    .unwrap();
+
+    let mut config = load_default_config_for_test(&code_home);
+    config.cwd = cwd.path().to_path_buf();
+    config.model_provider = model_provider;
+    config.model = "gpt-5.1-codex".to_string();
+    config.model_family = find_family_for_model(&config.model).unwrap();
+    config.memories_enabled = true;
+    config.memories.use_memories = true;
+    config.include_apply_patch_tool = false;
+    config.include_view_image_tool = false;
+    config.tools_web_search_request = false;
+    config.include_plan_tool = false;
+
+    let conversation_manager =
+        ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
+    let codex = conversation_manager
+        .new_conversation(config)
+        .await
+        .expect("create new conversation")
+        .conversation;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![InputItem::Text {
+                text: "hello".to_string(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await
+        .unwrap();
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+
+    let body = request.single_body_json();
+    let text = request_text(&body);
+
+    assert!(text.contains("## Memory"));
+    assert!(text.contains("sentinel memory guidance for request capture"));
+    assert!(text.contains(&format!(
+        "{} (already provided below; do NOT open again)",
+        memories_dir.join("memory_summary.md").display()
+    )));
+}


### PR DESCRIPTION
## Summary

- adds a focused core test that seeds `$CODE_HOME/memories/memory_summary.md`
- asserts the initial model request includes the memory section, sentinel memory text, and dedup marker path

## Validation

- `cargo test -p code-core --test prompt_context_dedup initial_session_request_injects_memory_when_summary_exists -- --nocapture`
- `./build-fast.sh`
