### PR TITLE
chore(release): prepare 0.6.111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - (none)
 
+## [0.6.111] - 2026-05-31
+
+- Skills: reject skills that reference missing command helpers so invalid workflow policies fail during load. (91eae015)
+
 ## [0.6.110] - 2026-05-31
 
 - Core: tell the model when another active session is using the same checkout so concurrent work is visible. (b8cd26d9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## [0.6.111] - 2026-05-31
 
-- Skills: reject skills that reference missing command helpers so invalid workflow policies fail during load. (91eae015)
+- Skills: add helper metadata for PR watching and issue digests, and reject skills whose command helpers are missing. (252e31ff, 91eae015)
 
 ## [0.6.110] - 2026-05-31
 

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.110",
+  "version": "0.6.111",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,10 +1,11 @@
 ## @just-every/code v0.6.111
 
-This release tightens skill workflow validation in Every Code.
+This release improves skill helper metadata and validation in Every Code.
 
 ### Changes
 
-- Reject skills that reference missing command helpers so invalid workflow policies fail during load.
+- Add structured command, resource, and default metadata for the repo-local PR watcher and issue digest skills.
+- Reject skills that reference missing command helpers so invalid workflow metadata fails during load.
 
 ### Install
 

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,17 +1,15 @@
-## @just-every/code v0.6.110
+## @just-every/code v0.6.111
 
-This release improves skill workflow rendering, concurrent-session awareness, and release workflow behavior in Every Code.
+This release tightens skill workflow validation in Every Code.
 
 ### Changes
 
-- Surface same-checkout concurrent sessions to the model so parallel local work has clearer context.
-- Render structured skill workflow metadata and enforce command policies even when commands appear inside shell segments.
-- Let release workflows exit cleanly when they determine no release should be published.
+- Reject skills that reference missing command helpers so invalid workflow policies fail during load.
 
 ### Install
 
 ```bash
-gh release download v0.6.110 --repo cbusillo/code
+gh release download v0.6.111 --repo cbusillo/code
 ```
 
-Compare: https://github.com/cbusillo/code/compare/v0.6.109...v0.6.110
+Compare: https://github.com/cbusillo/code/compare/v0.6.110...v0.6.111


### PR DESCRIPTION
## Summary
- bump @just-every/code to 0.6.111
- add release notes for the missing skill command helper validation hotfix

## Validation
- ./pre-release.sh
- just local-code-rebuild
- scripts/check-release-notes-version.sh --version 0.6.111