### PR TITLE
chore(release): 0.6.112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 - (none)
 
+## [0.6.112] - 2026-05-31
+
+- Skills: support repo and external skill commands while preserving compatibility for existing metadata. (61799048, a5221451)
+- Skills: require skill command helpers to use declared script resources so references and templates cannot masquerade as runnable helpers. (e9d33a8)
+- Upstream: add review cursor tracking and a local cursor report command for long-running fork maintenance. (11b169b0)
+
 ## [0.6.111] - 2026-05-31
 
 - Skills: add helper metadata for PR watching and issue digests, and reject skills whose command helpers are missing. (252e31ff, 91eae015)

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-every/code",
-  "version": "0.6.111",
+  "version": "0.6.112",
   "license": "Apache-2.0",
   "description": "Lightweight coding agent that runs in your terminal - fork of OpenAI Codex",
   "bin": {

--- a/docs/release-notes/RELEASE_NOTES.md
+++ b/docs/release-notes/RELEASE_NOTES.md
@@ -1,16 +1,17 @@
-## @just-every/code v0.6.111
+## @just-every/code v0.6.112
 
-This release improves skill helper metadata and validation in Every Code.
+This release tightens skill command metadata and adds upstream review cursor tooling.
 
 ### Changes
 
-- Add structured command, resource, and default metadata for the repo-local PR watcher and issue digest skills.
-- Reject skills that reference missing command helpers so invalid workflow metadata fails during load.
+- Support repo and external skill commands without breaking existing command metadata.
+- Reject skill commands that point at non-script resources, so templates and references cannot be treated as runnable helpers.
+- Add an upstream cursor report for tracking reviewed commits across Every Code's upstream sources.
 
 ### Install
 
 ```bash
-gh release download v0.6.111 --repo cbusillo/code
+gh release download v0.6.112 --repo cbusillo/code
 ```
 
-Compare: https://github.com/cbusillo/code/compare/v0.6.110...v0.6.111
+Compare: https://github.com/cbusillo/code/compare/v0.6.111...v0.6.112


### PR DESCRIPTION
## Summary
- bump @just-every/code to 0.6.112
- add changelog and GitHub release notes for the skill command and upstream cursor fixes

## Validation
- scripts/check-release-notes-version.sh --version 0.6.112
- ./pre-release.sh (first run hit one prompt_context_dedup assertion that passed in isolation; second full run passed: 1803 passed, 4 skipped)