### PR TITLE
docs(product): finish Every Code wording audit

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-codex-app.yml
+++ b/.github/ISSUE_TEMPLATE/1-codex-app.yml
@@ -1,5 +1,5 @@
-name: 🖥️ Codex App Bug
-description: Report an issue with the Codex App
+name: 🖥️ Every Code App Bug
+description: Report an issue with the Every Code app
 labels:
   - app
 body:
@@ -12,7 +12,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: What version of the Codex App are you using (From “About Codex” dialog)?
+      label: What version of the Every Code app are you using?
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/4-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/4-bug-report.yml
@@ -1,5 +1,5 @@
 name: 🪲 Other Bug
-description: Report an issue in Codex Web, integrations, or other Codex components
+description: Report an issue in Every Code integrations or other components
 labels:
   - bug
 body:
@@ -9,7 +9,7 @@ body:
         Before submitting a new issue, please search for existing issues to see if your issue has already been reported.
         If it has, please add a 👍 reaction (no need to leave a comment) to the existing issue instead of creating a new one.
 
-        If you need help or support using Codex and are not reporting a bug, please post on [codex/discussions](https://github.com/openai/codex/discussions), where you can ask questions or engage with others on ideas for how to improve codex.
+        If you need help or support using Every Code and are not reporting a bug, please post on [code/discussions](https://github.com/just-every/code/discussions), where you can ask questions or engage with others on ideas for how to improve Every Code.
 
   - type: textarea
     id: actual

--- a/.github/ISSUE_TEMPLATE/5-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/5-feature-request.yml
@@ -1,12 +1,12 @@
 name: 🎁 Feature Request
-description: Propose a new feature for Code
+description: Propose a new feature for Every Code
 labels:
   - enhancement
 body:
   - type: markdown
     attributes:
       value: |
-        Is Code missing a feature that you'd like to see? Feel free to propose it here.
+        Is Every Code missing a feature that you'd like to see? Feel free to propose it here.
 
         Before you submit a feature:
         1. Search existing issues for similar features. If you find one, 👍 it rather than opening a new one.
@@ -15,8 +15,8 @@ body:
   - type: input
     id: variant
     attributes:
-      label: What variant of Codex are you using?
-      description: (e.g., App, IDE Extension, CLI, Web)
+      label: What Every Code surface are you using?
+      description: (e.g., Every Code CLI, app, IDE integration, web)
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/6-docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/6-docs-issue.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for submitting a documentation request. It helps make Codex better.
+        Thank you for submitting a documentation request. It helps make Every Code better.
   - type: dropdown
     attributes:
       label: What is the type of issue?

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,10 +1,11 @@
 # Workflow Strategy
 
-Rust-specific `rust-ci*.yml` workflows are intentionally removed in this fork.
+Rust-specific `rust-ci*.yml` workflows are intentionally removed for Every Code.
 
 ## Verification Paths
 
-- `bazel.yml` is the primary Rust verification path for pull requests and for `main`.
+- `./build-fast.sh` is the required local Rust verification gate.
+- `preview-build.yml` builds preview binaries for pull requests.
 - `release.yml` is displayed in GitHub Actions as `Release Intent`. It runs
   after relevant `main` pushes, determines whether the committed
   `codex-cli/package.json` version has an existing `v<version>` tag, and either

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Completion/build step
 - Policy: All errors AND all warnings must be fixed before you’re done. Treat any compiler warning as a failure and address it (rename unused vars with `_`, remove `mut`, delete dead code, etc.).
 - Do not run additional format/lint/test commands on completion (e.g., `just fmt`, `just fix`, `cargo test`) unless explicitly requested for a specific task.
 - ***NEVER run rustfmt***
-- Before pushing to `main`, run `./pre-release.sh` to mirror the release preflight (dev-fast build, CLI smokes, workspace nextest).
+- Before release-bound work lands on `main`, run `./pre-release.sh` to mirror the release preflight (dev-fast build, CLI smokes, workspace nextest).
 
 Optional regression checks (recommended when touching the Rust workspace):
 

--- a/README.md
+++ b/README.md
@@ -342,9 +342,8 @@ The `pre-push` hook runs `./pre-release.sh` automatically when pushing to `main`
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/amazing-feature`
 3. Make your changes
-4. Run tests: `cargo test`
-5. Build successfully: `./build-fast.sh`
-6. Submit a pull request
+4. Build successfully: `./build-fast.sh`
+5. Submit a pull request
 
 
 &ensp;

--- a/docs/config.md
+++ b/docs/config.md
@@ -15,7 +15,8 @@ Every Code supports several mechanisms for setting config values:
     - Because quotes are interpreted by one's shell, `-c key="true"` will be correctly interpreted in TOML as `key = true` (a boolean) and not `key = "true"` (a string). If for some reason you needed the string `"true"`, you would need to use `-c key='"true"'` (note the two sets of quotes).
 - The `$CODE_HOME/config.toml` configuration file. `CODE_HOME` defaults to `~/.code`; Every Code also reads from `$CODEX_HOME`/`~/.codex` for backwards compatibility but only writes to `~/.code`. (Logs and other state use the same directory.) See [CODE and CODEX compatibility policy](./upstream-import-policy.md#code-and-codex-compatibility-policy) for naming and fallback rules.
 
-- https://developers.openai.com/codex/config-reference
+- Upstream compatibility reference:
+  https://developers.openai.com/codex/config-reference
 
 ## model
 

--- a/docs/upstream-import-policy.md
+++ b/docs/upstream-import-policy.md
@@ -117,7 +117,7 @@ outside the product branch and must be replayed.
 
 ### Upstream Review Cursors
 
-Every Code is a long-running overlay product with two upstream references. Track
+Every Code is a product branch with two upstream references. Track
 where review left off in `.github/upstream-cursors.json`, and inspect that state
 with:
 
@@ -206,6 +206,25 @@ repo-owned and predictable:
 just local-remove-homebrew-code-link
 ```
 
+Then push the release metadata branch to `origin`, merge the release metadata
+PR, and monitor the `Release Intent` workflow:
+
+```sh
+git push origin HEAD
+scripts/wait-for-gh-run.sh --workflow 'Release Intent' --branch main
+```
+
+A successful workflow run is not enough evidence that a release was published:
+non-release runs also complete successfully as no-ops when the package version
+already has a tag. When cutting a release, verify the tag or GitHub Release
+directly after the workflow succeeds:
+
+```sh
+gh release view v<version> --repo cbusillo/code
+```
+
+Do not push Every Code releases to `upstream` or `openai`.
+
 ## Local Cache Cleanup
 
 During active local work, keep rebuildable caches bounded while preserving the
@@ -235,25 +254,6 @@ target cache buckets, and release dependency cache. It preserves
 
 Run without `--apply` to preview deletions. Use `--keep-release-cache` only when
 you intentionally want to preserve release dependency cache as well.
-
-Then push the release metadata branch to `origin`, merge the release metadata
-PR, and monitor the `Release Intent` workflow:
-
-```sh
-git push origin HEAD
-scripts/wait-for-gh-run.sh --workflow 'Release Intent' --branch main
-```
-
-A successful workflow run is not enough evidence that a release was published:
-non-release runs also complete successfully as no-ops when the package version
-already has a tag. When cutting a release, verify the tag or GitHub Release
-directly after the workflow succeeds:
-
-```sh
-gh release view v<version> --repo cbusillo/code
-```
-
-Do not push Every Code releases to `upstream` or `openai`.
 
 ## Fork Health
 


### PR DESCRIPTION
## Summary
- update issue templates that still described Codex/OpenAI surfaces
- remove stale workflow guidance for missing bazel.yml and align contributor validation with ./build-fast.sh
- clarify upstream cursor/release docs around product-branch framing and release monitoring

## Validation
- rg stale Codex/release phrases across edited surfaces
- bash -n scripts/wait-for-gh-run.sh
- jq empty .github/github.json
- YAML parse for issue templates and touched workflows
- scripts/check-release-notes-version.sh --version 0.6.112
- ./build-fast.sh