### PR TITLE
Add Auto Review prompt diagnostics

### DIFF
--- a/code-rs/core/src/review_store.rs
+++ b/code-rs/core/src/review_store.rs
@@ -746,6 +746,20 @@ fn append_ledger_run(lines: &mut Vec<String>, run: &AutoReviewRun, now: u64) {
     if let Some(agent_id) = run.agent_id.as_deref().and_then(short_agent_id) {
         line.push_str(&format!(" agent={agent_id}"));
     }
+    if let Some(model) = run.model.as_deref() {
+        line.push_str(" model=");
+        line.push_str(&single_line(model, 40));
+    }
+    if let Some(reasoning_effort) = run.reasoning_effort.as_deref() {
+        line.push_str(" reasoning=");
+        line.push_str(&single_line(reasoning_effort, 24));
+    }
+    if let Some(prompt_token_estimate) = run.prompt_token_estimate {
+        line.push_str(&format!(" prompt_estimate={}t", prompt_token_estimate));
+    }
+    if let Some(token_count) = run.token_count {
+        line.push_str(&format!(" tokens={}t", token_count));
+    }
     if run.finding_count > 0 {
         line.push_str(&format!(" findings={}", run.finding_count));
     }
@@ -1219,6 +1233,10 @@ mod tests {
         run.agent_id = Some("agent-1234567890".to_string());
         run.branch = Some("auto-review".to_string());
         run.snapshot_commit = Some("abcdef1234567890".to_string());
+        run.model = Some("gpt-5.4-mini".to_string());
+        run.reasoning_effort = Some("medium".to_string());
+        run.prompt_token_estimate = Some(42_000);
+        run.token_count = Some(84_000);
         run.freshness = AutoReviewFreshness::Current;
         run.mark_activity(120);
         run.mark_status(AutoReviewRunStatus::Reviewing, 130);
@@ -1231,6 +1249,10 @@ mod tests {
         assert!(ledger.contains("status=Reviewing"));
         assert!(ledger.contains("last_activity=40s"));
         assert!(ledger.contains("snapshot=abcdef123456"));
+        assert!(ledger.contains("model=gpt-5.4-mini"));
+        assert!(ledger.contains("reasoning=medium"));
+        assert!(ledger.contains("prompt_estimate=42000t"));
+        assert!(ledger.contains("tokens=84000t"));
     }
 
     #[test]

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -1735,6 +1735,20 @@ fn persist_auto_review_scope_metadata(
     store.save()
 }
 
+fn persist_auto_review_prompt_estimate(
+    cwd: &Path,
+    run_id: Uuid,
+    prompt_token_estimate: u64,
+) -> std::io::Result<()> {
+    let now = unix_now_secs();
+    let mut store = AutoReviewRunStore::open(cwd)?;
+    if let Some(run) = store.get_mut(run_id) {
+        run.prompt_token_estimate = Some(prompt_token_estimate);
+        run.mark_activity(now);
+    }
+    store.save()
+}
+
 fn find_duplicate_auto_review_run(
     cwd: &Path,
     diff_fingerprint: &str,
@@ -32114,6 +32128,14 @@ async fn run_background_review(
             turn_context.as_deref(),
             prompt_token_budget,
         );
+        let prompt_token_estimate = estimate_auto_review_prompt_tokens(&review_prompt);
+        if let Err(err) = persist_auto_review_prompt_estimate(
+            &config.cwd,
+            run_id,
+            prompt_token_estimate,
+        ) {
+            tracing::warn!(?err, run_id = %run_id, "failed to persist auto-review prompt estimate");
+        }
 
         let mut manager = code_core::AGENT_MANAGER.write().await;
         let agent_id = manager
@@ -33036,6 +33058,28 @@ use code_core::protocol::OrderMeta;
         assert!(prompt.contains("Snapshot: abc123."));
         assert!(estimate_auto_review_prompt_tokens(&prompt) <= 800);
         assert!(prompt.contains("```diff") || prompt.contains("Changed files to prioritize"));
+    }
+
+    #[test]
+    fn auto_review_prompt_estimate_is_persisted() {
+        let _stub_lock = AUTO_STUB_LOCK.lock().unwrap();
+        let code_home = tempfile::tempdir().expect("code home");
+        // SAFETY: guarded by AUTO_STUB_LOCK so tests in this module do not race CODE_HOME.
+        unsafe { std::env::set_var("CODE_HOME", code_home.path()); }
+        let cwd = tempfile::tempdir().expect("repo cwd");
+        let run_id = Uuid::new_v4();
+        let mut store = AutoReviewRunStore::open(cwd.path()).expect("open store");
+        store
+            .upsert(AutoReviewRun::new(run_id, AutoReviewRunSource::Tui, 1))
+            .expect("insert run");
+
+        persist_auto_review_prompt_estimate(cwd.path(), run_id, 12_345)
+            .expect("persist prompt estimate");
+
+        let loaded = AutoReviewRunStore::open(cwd.path()).expect("reload store");
+        let run = loaded.get(run_id).expect("run loaded");
+        assert_eq!(run.prompt_token_estimate, Some(12_345));
+        assert!(run.last_activity_at.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n\n- persist Auto Review prompt token estimates after the background review prompt is built\n- include model, reasoning effort, prompt estimate, and actual token count in the compact Auto Review ledger when available\n- add focused regression coverage for prompt estimate persistence and ledger projection\n\n## Plan Links\n\nRefs #330\nRefs #50\nRefs #324\n\n## Validation\n\n- cargo test -p code-core compact_ledger_includes_active_run_activity_and_snapshot --lib\n- cargo test -p code-tui auto_review_prompt_estimate_is_persisted --features test-helpers\n- ./build-fast.sh\n