### PR TITLE
test: stabilize release preflight fixtures

### DIFF
--- a/code-rs/core/src/active_sessions.rs
+++ b/code-rs/core/src/active_sessions.rs
@@ -381,7 +381,7 @@ mod tests {
 
         let notice = active_session_model_notice(&second.conflicts).unwrap();
         assert!(notice.contains("CONCURRENT CHECKOUT SESSION DETECTED"));
-        assert!(notice.contains("separate git worktree"));
+        assert!(notice.contains("isolated git worktree"));
         assert!(notice.contains("re-read target files"));
         assert!(notice.contains("Do not revert, overwrite, stage"));
         assert!(notice.contains(repo.path().canonicalize().unwrap().to_string_lossy().as_ref()));

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -34219,6 +34219,7 @@ use code_core::protocol::OrderMeta;
         let run_id = uuid::Uuid::new_v4();
         chat.session_id = Some(session_id);
         chat.background_review_run_id = Some(run_id);
+        chat.auto_review_reviewed_marker = None;
         chat.background_review = Some(BackgroundReviewState {
             worktree_path: PathBuf::new(),
             branch: String::new(),
@@ -35266,7 +35267,7 @@ use code_core::protocol::OrderMeta;
         chat.background_review = Some(BackgroundReviewState {
             worktree_path: PathBuf::from("/tmp/wt"),
             branch: "auto-review-branch".to_string(),
-            agent_id: None,
+            agent_id: Some("agent-1".to_string()),
             snapshot: Some("ghost123".to_string()),
             owner_session_id: None,
             base: None,
@@ -35296,7 +35297,7 @@ use code_core::protocol::OrderMeta;
             seconds_since_last_activity: None,
             source_kind: Some(AgentSourceKind::AutoReview),
             owner_session_id: None,
-            worktree_base: None,
+            worktree_base: Some("ghost123".to_string()),
         };
 
         chat.observe_auto_review_status(&[agent]);


### PR DESCRIPTION
## Summary
- update active-session guidance test for the current isolated-worktree copy
- seed realistic auto-review identity fields in the idle observer fixture
- reset the skipped-review marker precondition so the test is deterministic under full nextest

## Validation
- cargo test --manifest-path code-rs/Cargo.toml -p code-core active_sessions::tests::model_notice_gives_concurrent_editing_guidance -- --nocapture
- cargo test --manifest-path code-rs/Cargo.toml -p code-tui background_review_observe_idle_renders_notice_and_post_turn_input_from_agent_result --features test-helpers -- --nocapture
- cargo test --manifest-path code-rs/Cargo.toml -p code-tui duplicate_skipped_background_review_does_not_mark_snapshot_reviewed --features test-helpers -- --nocapture
- ./build-fast.sh
- CODE_HOME=$(mktemp -d /tmp/code-pre-release-code-home.XXXXXX) CODEX_HOME=$CODE_HOME ./pre-release.sh

Agent review: two read-only reviewers found no issues and agreed these are fixture/isolation fixes.