### PR TITLE
Initialize chat widget harness cwd as git repo

### DIFF
--- a/code-rs/tui/src/chatwidget/smoke_helpers.rs
+++ b/code-rs/tui/src/chatwidget/smoke_helpers.rs
@@ -87,6 +87,12 @@ impl ChatWidgetHarness {
 
         let code_home = TempDir::new().expect("temp code home");
         let cwd = TempDir::new().expect("temp cwd");
+        std::process::Command::new("git")
+            .arg("init")
+            .arg("--quiet")
+            .current_dir(cwd.path())
+            .status()
+            .expect("git init temp cwd");
 
         let cfg = Config::load_from_base_config_with_overrides(
             ConfigToml::default(),


### PR DESCRIPTION
## Summary
- Initializes the isolated `ChatWidgetHarness` cwd as a quiet git repository.
- Restores test coverage for write-capable auto-drive agent behavior while keeping auto-review state isolated from the real checkout.

## Validation
- `cargo test --manifest-path code-rs/Cargo.toml -p code-tui chatwidget::tests::auto_handle_decision_launches_cli_agents_and_review --features test-helpers -- --nocapture`
- `cargo test --manifest-path code-rs/Cargo.toml -p code-tui --test vt100_chatwidget_snapshot baseline_empty_chat --features test-helpers -- --nocapture`
- `./build-fast.sh`
