### PR TITLE
Make chat widget harness git setup opt-in

### DIFF
--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -38668,7 +38668,7 @@ use code_core::protocol::OrderMeta;
 
     #[test]
     fn auto_handle_decision_launches_cli_agents_and_review() {
-        let mut harness = ChatWidgetHarness::new();
+        let mut harness = ChatWidgetHarness::new_in_git_repo();
         let chat = harness.chat();
 
         chat.auto_state.set_phase(AutoRunPhase::Active);

--- a/code-rs/tui/src/chatwidget/smoke_helpers.rs
+++ b/code-rs/tui/src/chatwidget/smoke_helpers.rs
@@ -73,6 +73,14 @@ impl AutoContinueModeFixture {
 
 impl ChatWidgetHarness {
     pub fn new() -> Self {
+        Self::new_with_git_repo(false)
+    }
+
+    pub fn new_in_git_repo() -> Self {
+        Self::new_with_git_repo(true)
+    }
+
+    fn new_with_git_repo(init_git: bool) -> Self {
         // Stabilize time-of-day dependent greeting so VT100 snapshots remain deterministic.
         // Safe: tests run single-threaded by design.
         unsafe { std::env::set_var("CODEX_TUI_FAKE_HOUR", "12"); }
@@ -87,12 +95,14 @@ impl ChatWidgetHarness {
 
         let code_home = TempDir::new().expect("temp code home");
         let cwd = TempDir::new().expect("temp cwd");
-        std::process::Command::new("git")
-            .arg("init")
-            .arg("--quiet")
-            .current_dir(cwd.path())
-            .status()
-            .expect("git init temp cwd");
+        if init_git {
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("--quiet")
+                .current_dir(cwd.path())
+                .status()
+                .expect("git init temp cwd");
+        }
 
         let cfg = Config::load_from_base_config_with_overrides(
             ConfigToml::default(),


### PR DESCRIPTION
## Summary
- Keeps the default `ChatWidgetHarness` isolated and PATH-agnostic.
- Adds `ChatWidgetHarness::new_in_git_repo()` for tests that explicitly need git semantics.
- Updates the auto-drive write-agent test to opt into a git-backed harness.

## Validation
- `cargo test --manifest-path code-rs/Cargo.toml -p code-tui chatwidget::tests::auto_handle_decision_launches_cli_agents_and_review --features test-helpers -- --nocapture`
- `cargo test --manifest-path code-rs/Cargo.toml -p code-tui chatwidget::tests::missing_agent_clis_start_disabled_in_overview --features test-helpers -- --nocapture`
- `./build-fast.sh`
