### PR TITLE
ci: fix release dry-run matrix runs-on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
         (needs.determine-version.outputs.release_intent == 'true' && needs.validate-release-metadata.result == 'success') ||
         (github.event_name == 'workflow_dispatch' && inputs.release_build_dry_run == true)
       )
-    runs-on: ${{ fromJson(matrix.runs_on) }}
+    runs-on: ${{ matrix.runs_on }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
       RUSTUP_HOME: ${{ github.workspace }}/.rustup-home


### PR DESCRIPTION
## Summary
- fix the release dry-run build job to use matrix `runs_on` arrays directly
- avoids re-parsing an already-decoded matrix value during job expansion

## Validation
- `actionlint .github/workflows/release.yml`
- YAML parse
- JSON parse
- `git diff --check`
- `./build-fast.sh`

## Notes
The failed dry-run run did not publish a release; publish stayed skipped and no build matrix jobs started.