### PR TITLE
Show lost Auto Review restarts as unavailable

### DIFF
--- a/code-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/code-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2575,6 +2575,15 @@ impl ChatComposer {
                     Span::styled("Failed", icon_style),
                 ]
             }
+            AutoReviewIndicatorStatus::Unavailable => {
+                let icon_style = Style::default().fg(crate::colors::text_dim());
+                vec![
+                    Span::styled("Auto Review: ", label_style),
+                    Span::styled("•", icon_style),
+                    Span::from(" "),
+                    Span::styled("Unavailable", icon_style),
+                ]
+            }
         };
 
         if let Some(detail) = status.detail.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
@@ -3546,6 +3555,37 @@ mod tests {
 
         assert!(line.contains("Auto Review: • Reviewing"), "line: {line}");
         assert!(line.contains("(25m, stale, snap abcdef1)"), "line: {line}");
+    }
+
+    #[test]
+    fn auto_review_footer_shows_lost_restart_as_unavailable() {
+        let (tx, _rx) = std::sync::mpsc::channel::<AppEvent>();
+        let app_tx = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(true, app_tx, true, false);
+
+        composer.set_auto_review_status(Some(AutoReviewFooterStatus {
+            status: AutoReviewIndicatorStatus::Unavailable,
+            findings: None,
+            phase: AutoReviewPhase::Reviewing,
+            detail: Some("lost after restart".to_string()),
+        }));
+
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 1,
+        };
+        let mut buf = Buffer::empty(area);
+        composer.render_footer(area, &mut buf);
+
+        let line: String = (0..area.width)
+            .map(|x| buf[(area.x + x, area.y)].symbol().to_string())
+            .collect();
+
+        assert!(line.contains("Auto Review: • Unavailable"), "line: {line}");
+        assert!(line.contains("(lost after restart)"), "line: {line}");
+        assert!(!line.contains("Failed"), "line: {line}");
     }
 
     #[test]

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -1464,6 +1464,7 @@ pub(crate) enum AutoReviewIndicatorStatus {
     Clean,
     Fixed,
     Failed,
+    Unavailable,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -33238,7 +33239,7 @@ use code_core::protocol::OrderMeta;
         assert!(
             chat.auto_review_status
                 .as_ref()
-                .is_some_and(|state| state.status == AutoReviewIndicatorStatus::Failed)
+                .is_some_and(|state| state.status == AutoReviewIndicatorStatus::Unavailable)
         );
 
         let notice_text = chat
@@ -33355,7 +33356,7 @@ use code_core::protocol::OrderMeta;
         assert!(
             chat.auto_review_status
                 .as_ref()
-                .is_some_and(|state| state.status == AutoReviewIndicatorStatus::Failed)
+                .is_some_and(|state| state.status == AutoReviewIndicatorStatus::Unavailable)
         );
 
         let notice_text = chat
@@ -35053,6 +35054,45 @@ use code_core::protocol::OrderMeta;
                 .auto_review_status()
                 .and_then(|status| status.detail),
             Some("snap abcdef1".to_string())
+        );
+    }
+
+    #[test]
+    fn background_review_started_replaces_unavailable_restart_status() {
+        let mut harness = ChatWidgetHarness::new();
+        let chat = harness.chat();
+        let run_id = uuid::Uuid::new_v4();
+        chat.config.tui.auto_review_enabled = true;
+        chat.background_review_run_id = Some(run_id);
+        chat.set_auto_review_indicator_with_detail(
+            AutoReviewIndicatorStatus::Unavailable,
+            None,
+            AutoReviewPhase::Reviewing,
+            Some("lost after restart".to_string()),
+        );
+
+        chat.on_background_review_started_for_run(
+            run_id,
+            PathBuf::from("/tmp/wt"),
+            "auto-review-branch".to_string(),
+            Some("agent-123".to_string()),
+            Some("abcdef123456".to_string()),
+            None,
+        );
+
+        assert_eq!(
+            chat.auto_review_status.as_ref().map(|status| status.status),
+            Some(AutoReviewIndicatorStatus::Running)
+        );
+        assert_eq!(
+            chat.bottom_pane.auto_review_status().map(|status| status.status),
+            Some(AutoReviewIndicatorStatus::Running)
+        );
+        assert_ne!(
+            chat.bottom_pane
+                .auto_review_status()
+                .and_then(|status| status.detail),
+            Some("lost after restart".to_string())
         );
     }
 
@@ -42610,7 +42650,7 @@ impl ChatWidget<'_> {
         }
 
         self.set_auto_review_indicator_with_detail(
-            AutoReviewIndicatorStatus::Failed,
+            AutoReviewIndicatorStatus::Unavailable,
             None,
             AutoReviewPhase::Reviewing,
             Some("lost after restart".to_string()),
@@ -43603,7 +43643,10 @@ impl ChatWidget<'_> {
         );
         let detail = auto_review_running_detail(self.background_review.as_ref(), None, None);
         if let Some(status) = self.auto_review_status.clone() {
-            if status.status == AutoReviewIndicatorStatus::Running {
+            if matches!(
+                status.status,
+                AutoReviewIndicatorStatus::Running | AutoReviewIndicatorStatus::Unavailable
+            ) {
                 self.set_auto_review_indicator_with_detail(
                     AutoReviewIndicatorStatus::Running,
                     status.findings,


### PR DESCRIPTION
## Summary\n- add a neutral Auto Review footer state for restart-lost runs\n- render restart-lost Auto Review as unavailable instead of failed\n- keep actual failed Auto Review runs mapped to the red Failed state\n\nFixes #369\n\n## Validation\n- cargo test --manifest-path code-rs/Cargo.toml -p code-tui auto_review\n- ./build-fast.sh