### PR TITLE
Distinguish auto-review freshness from target applicability

### DIFF
--- a/code-rs/core/src/codex/streaming.rs
+++ b/code-rs/core/src/codex/streaming.rs
@@ -1563,14 +1563,33 @@ fn build_auto_review_ledger_message(cwd: &Path) -> Option<String> {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs())
         .unwrap_or(0);
+    let active_branch = git_output_sync(cwd, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .filter(|branch| branch != "HEAD");
+    let active_head = git_output_sync(cwd, &["rev-parse", "HEAD"]);
     match AutoReviewRunStore::open_existing(cwd) {
-        Ok(Some(store)) => store.compact_ledger(AutoReviewLedgerOptions::new(now)),
+        Ok(Some(store)) => store.compact_ledger(
+            AutoReviewLedgerOptions::new(now).with_active_target(active_branch, active_head),
+        ),
         Ok(None) => None,
         Err(err) => {
             tracing::warn!(?err, "failed to open auto-review run store for request ledger");
             None
         }
     }
+}
+
+fn git_output_sync(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    let value = value.trim().to_string();
+    (!value.is_empty()).then_some(value)
 }
 
 fn current_turn_insert_at(

--- a/code-rs/core/src/review_store.rs
+++ b/code-rs/core/src/review_store.rs
@@ -87,6 +87,25 @@ pub enum AutoReviewFreshness {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoReviewTargetApplicability {
+    MatchingHead,
+    OlderSnapshot,
+    DetachedReviewWorktree,
+    Unknown,
+}
+
+impl AutoReviewTargetApplicability {
+    fn as_ledger_value(self) -> &'static str {
+        match self {
+            AutoReviewTargetApplicability::MatchingHead => "matching_head",
+            AutoReviewTargetApplicability::OlderSnapshot => "older_snapshot",
+            AutoReviewTargetApplicability::DetachedReviewWorktree => "detached_review_worktree",
+            AutoReviewTargetApplicability::Unknown => "unknown",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AutoReviewFindingDigest {
     pub finding_id: String,
@@ -252,11 +271,13 @@ pub struct AutoReviewDuplicateMatch {
     pub summary_digest: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct AutoReviewLedgerOptions {
     pub max_bytes: usize,
     pub max_runs: usize,
     pub now: u64,
+    pub active_branch: Option<String>,
+    pub active_head: Option<String>,
 }
 
 impl AutoReviewLedgerOptions {
@@ -265,7 +286,19 @@ impl AutoReviewLedgerOptions {
             max_bytes: DEFAULT_LEDGER_MAX_BYTES,
             max_runs: DEFAULT_LEDGER_MAX_RUNS,
             now,
+            active_branch: None,
+            active_head: None,
         }
+    }
+
+    pub fn with_active_target(
+        mut self,
+        active_branch: Option<String>,
+        active_head: Option<String>,
+    ) -> Self {
+        self.active_branch = active_branch.and_then(non_empty_string);
+        self.active_head = active_head.and_then(non_empty_string);
+        self
     }
 }
 
@@ -681,12 +714,12 @@ where
     lines.push(format!(
         "<auto_review_ledger schema_version=\"1\" max_bytes=\"{max_bytes}\">"
     ));
-    lines.push("Auto Review state for this repo. Details are not included in this request; treat run ids as stable references for future detail lookup.".to_string());
+    lines.push("Auto Review state for this repo. Details are not included in this request; treat run ids as stable references for future detail lookup. Freshness describes run recency; target describes whether findings match the active checkout.".to_string());
     if let Some(diagnostics) = diagnostics {
         lines.push(diagnostics);
     }
     for run in selected {
-        append_ledger_run(&mut lines, run, options.now);
+        append_ledger_run(&mut lines, run, &options);
     }
     lines.push("</auto_review_ledger>".to_string());
 
@@ -695,6 +728,43 @@ where
         truncate_ledger_to_bytes(&mut ledger, max_bytes);
     }
     Some(ledger)
+}
+
+pub fn auto_review_target_applicability(
+    run: &AutoReviewRun,
+    active_branch: Option<&str>,
+    active_head: Option<&str>,
+) -> AutoReviewTargetApplicability {
+    let active_head = active_head.and_then(non_empty_str);
+    let active_branch = active_branch.and_then(non_empty_str);
+    let snapshot = run.snapshot_commit.as_deref().and_then(non_empty_str);
+    let head_at_launch = run.head_at_launch.as_deref().and_then(non_empty_str);
+
+    if let (Some(snapshot), Some(active_head)) = (snapshot, active_head) {
+        if same_commit_prefix(snapshot, active_head) {
+            return AutoReviewTargetApplicability::MatchingHead;
+        }
+    }
+    if let (Some(head_at_launch), Some(active_head)) = (head_at_launch, active_head) {
+        if same_commit_prefix(head_at_launch, active_head) {
+            return AutoReviewTargetApplicability::MatchingHead;
+        }
+    }
+
+    let review_branch = run.branch.as_deref().and_then(non_empty_str);
+    let detached_review_branch = review_branch.is_some_and(is_auto_review_branch);
+    if active_head.is_some() && detached_review_branch && review_branch != active_branch {
+        return AutoReviewTargetApplicability::DetachedReviewWorktree;
+    }
+
+    if snapshot.is_some() && active_head.is_some() {
+        return AutoReviewTargetApplicability::OlderSnapshot;
+    }
+    if head_at_launch.is_some() && active_head.is_some() {
+        return AutoReviewTargetApplicability::OlderSnapshot;
+    }
+
+    AutoReviewTargetApplicability::Unknown
 }
 
 fn run_is_ledger_actionable(run: &AutoReviewRun, now: u64) -> bool {
@@ -889,7 +959,8 @@ fn ledger_priority(run: &AutoReviewRun) -> u8 {
     1
 }
 
-fn append_ledger_run(lines: &mut Vec<String>, run: &AutoReviewRun, now: u64) {
+fn append_ledger_run(lines: &mut Vec<String>, run: &AutoReviewRun, options: &AutoReviewLedgerOptions) {
+    let now = options.now;
     let age_secs = now.saturating_sub(run.updated_at);
     let activity_age_secs = run
         .last_activity_at
@@ -900,11 +971,17 @@ fn append_ledger_run(lines: &mut Vec<String>, run: &AutoReviewRun, now: u64) {
         .and_then(short_sha)
         .unwrap_or("unknown");
     let branch = run.branch.as_deref().or(run.batch_id.as_deref()).unwrap_or("unknown");
+    let target = auto_review_target_applicability(
+        run,
+        options.active_branch.as_deref(),
+        options.active_head.as_deref(),
+    );
     let mut line = format!(
-        "run id={} status={:?} freshness={:?} source={:?} branch={} snapshot={} age={}",
+        "run id={} status={:?} freshness={:?} target={} source={:?} branch={} snapshot={} age={}",
         run.run_id,
         run.status,
         run.freshness,
+        target.as_ledger_value(),
         run.source,
         branch,
         snapshot,
@@ -997,6 +1074,30 @@ fn short_agent_id(value: &str) -> Option<&str> {
     }
 }
 
+fn non_empty_string(value: String) -> Option<String> {
+    let value = value.trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn non_empty_str(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+fn is_auto_review_branch(value: &str) -> bool {
+    value == "auto-review" || value.starts_with("auto-review-")
+}
+
+fn same_commit_prefix(left: &str, right: &str) -> bool {
+    let left = left.trim();
+    let right = right.trim();
+    if !left.is_ascii() || !right.is_ascii() {
+        return false;
+    }
+    let min_len = left.len().min(right.len());
+    min_len >= 7 && left[..min_len].eq_ignore_ascii_case(&right[..min_len])
+}
+
 fn single_line(value: &str, max_chars: usize) -> String {
     let flattened = value.split_whitespace().collect::<Vec<_>>().join(" ");
     summarize(&flattened, max_chars).unwrap_or_default()
@@ -1086,6 +1187,8 @@ mod tests {
             now,
             max_bytes: 2_400,
             max_runs: 5,
+            active_branch: None,
+            active_head: None,
         }
     }
 
@@ -1425,11 +1528,106 @@ mod tests {
         assert!(ledger.contains("status=Reviewing"));
         assert!(ledger.contains("last_activity=lt1m"));
         assert!(ledger.contains("snapshot=abcdef123456"));
+        assert!(ledger.contains("target=unknown"));
         assert!(ledger.contains("model=gpt-5.4-mini"));
         assert!(ledger.contains("reasoning=medium"));
         assert!(ledger.contains("prompt_estimate=42000t"));
         assert!(ledger.contains("tokens=84000t"));
         assert!(ledger.contains("elapsed=lt1m"));
+    }
+
+    #[test]
+    #[serial]
+    fn compact_ledger_marks_matching_head_target_separately_from_freshness() {
+        let code_home = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+        set_code_home(code_home.path());
+        let mut run = AutoReviewRun::new(Uuid::new_v4(), AutoReviewRunSource::Tui, 10);
+        run.branch = Some("feature".to_string());
+        run.snapshot_commit = Some("abcdef1234567890".to_string());
+        run.finding_count = 1;
+        run.finding_digests = vec![finding_digest(1)];
+        run.mark_status(AutoReviewRunStatus::Completed, 20);
+        let mut store = AutoReviewRunStore::open(repo.path()).unwrap();
+        store.upsert(run).unwrap();
+
+        let ledger = store
+            .compact_ledger(
+                ledger_options(30).with_active_target(
+                    Some("feature".to_string()),
+                    Some("abcdef1234567890".to_string()),
+                ),
+            )
+            .expect("ledger");
+
+        assert!(ledger.contains("freshness=Unknown"));
+        assert!(ledger.contains("target=matching_head"));
+    }
+
+    #[test]
+    #[serial]
+    fn compact_ledger_marks_launch_head_mismatch_as_older_snapshot() {
+        let code_home = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+        set_code_home(code_home.path());
+        let mut run = AutoReviewRun::new(Uuid::new_v4(), AutoReviewRunSource::Tui, 10);
+        run.branch = Some("feature".to_string());
+        run.head_at_launch = Some("aaaaaaaaaaaaaaaa".to_string());
+        run.finding_count = 1;
+        run.finding_digests = vec![finding_digest(1)];
+        run.mark_status(AutoReviewRunStatus::Completed, 20);
+        let mut store = AutoReviewRunStore::open(repo.path()).unwrap();
+        store.upsert(run).unwrap();
+
+        let ledger = store
+            .compact_ledger(
+                ledger_options(30).with_active_target(
+                    Some("feature".to_string()),
+                    Some("bbbbbbbbbbbbbbbb".to_string()),
+                ),
+            )
+            .expect("ledger");
+
+        assert!(ledger.contains("target=older_snapshot"));
+        assert!(!ledger.contains("target=matching_head"));
+    }
+
+    #[test]
+    #[serial]
+    fn compact_ledger_marks_detached_and_older_review_targets() {
+        let code_home = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+        set_code_home(code_home.path());
+        let mut detached = AutoReviewRun::new(Uuid::new_v4(), AutoReviewRunSource::Tui, 10);
+        detached.branch = Some("auto-review".to_string());
+        detached.snapshot_commit = Some("1111111111111111".to_string());
+        detached.finding_count = 1;
+        detached.finding_digests = vec![finding_digest(1)];
+        detached.mark_status(AutoReviewRunStatus::Completed, 20);
+
+        let mut older = AutoReviewRun::new(Uuid::new_v4(), AutoReviewRunSource::Tui, 30);
+        older.branch = Some("feature".to_string());
+        older.snapshot_commit = Some("2222222222222222".to_string());
+        older.finding_count = 1;
+        older.finding_digests = vec![finding_digest(2)];
+        older.mark_status(AutoReviewRunStatus::Completed, 40);
+
+        let mut store = AutoReviewRunStore::open(repo.path()).unwrap();
+        store.upsert(detached).unwrap();
+        store.upsert(older).unwrap();
+
+        let ledger = store
+            .compact_ledger(
+                ledger_options(50).with_active_target(
+                    Some("feature".to_string()),
+                    Some("3333333333333333".to_string()),
+                ),
+            )
+            .expect("ledger");
+
+        assert!(ledger.contains("target=detached_review_worktree"));
+        assert!(ledger.contains("target=older_snapshot"));
+        assert!(ledger.contains("Freshness describes run recency"));
     }
 
     #[test]
@@ -1640,6 +1838,8 @@ mod tests {
                 now: 20,
                 max_bytes: 180,
                 max_runs: 10,
+                active_branch: None,
+                active_head: None,
             })
             .expect("ledger");
         assert!(ledger.len() <= 180, "ledger len was {}", ledger.len());

--- a/code-rs/exec/src/lib.rs
+++ b/code-rs/exec/src/lib.rs
@@ -848,11 +848,11 @@ pub async fn run_main(cli: Cli, code_linux_sandbox_exe: Option<PathBuf>) -> anyh
                     } else {
                         match summary {
                             Some(ref text) if !text.is_empty() => eprintln!(
-                                "[developer] Auto-review found {findings_count} issue(s) on branch '{branch}'. Summary: {text}. Worktree: {}. Merge this worktree/branch to apply fixes.",
+                                "[developer] Auto-review found {findings_count} issue(s) on branch '{branch}'. Summary: {text}. Worktree: {}. Re-validate against current HEAD before merging fixes.",
                                 worktree.display()
                             ),
                             _ => eprintln!(
-                                "[developer] Auto-review found {findings_count} issue(s) on branch '{branch}'. Worktree: {}. Merge this worktree/branch to apply fixes.",
+                                "[developer] Auto-review found {findings_count} issue(s) on branch '{branch}'. Worktree: {}. Re-validate against current HEAD before merging fixes.",
                                 worktree.display()
                             ),
                         }
@@ -1965,7 +1965,7 @@ fn emit_auto_review_completion(completion: &AutoReviewCompletion) {
         let count = completion.summary.findings.max(1);
         if let Some(path) = completion.worktree_path.as_ref() {
             eprintln!(
-                "[auto-review] {branch}: {count} issue(s) found. Merge {} to apply fixes. Summary: {summary_text}",
+                "[auto-review] {branch}: {count} issue(s) found. Re-validate {} against current HEAD before merging fixes. Summary: {summary_text}",
                 path.display()
             );
         } else {

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -33207,6 +33207,69 @@ use code_core::protocol::OrderMeta;
     }
 
     #[test]
+    fn auto_review_completion_preserves_launch_head_after_checkout_moves() {
+        let _stub_lock = AUTO_STUB_LOCK.lock().unwrap();
+        let repo = tempdir().expect("temp repo");
+        let repo_path = repo.path();
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .current_dir(repo_path)
+                .args(args)
+                .status()
+                .expect("git command");
+            assert!(status.success(), "git command failed: {args:?}");
+        };
+        let git_output = |args: &[&str]| -> String {
+            let output = Command::new("git")
+                .current_dir(repo_path)
+                .args(args)
+                .output()
+                .expect("git command");
+            assert!(output.status.success(), "git command failed: {args:?}");
+            String::from_utf8(output.stdout).expect("utf8 stdout").trim().to_string()
+        };
+        git(&["init", "--quiet"]);
+        git(&["config", "user.email", "auto@review.test"]);
+        git(&["config", "user.name", "Auto Review"]);
+        std::fs::write(repo_path.join("README.md"), "hello").expect("write README");
+        git(&["add", "."]);
+        git(&["commit", "--quiet", "-m", "init"]);
+        let launch_head = git_output(&["rev-parse", "HEAD"]);
+
+        let mut harness = ChatWidgetHarness::new();
+        let chat = harness.chat();
+        chat.config.cwd = repo_path.to_path_buf();
+        let run_id = uuid::Uuid::new_v4();
+        let owner_session_id = uuid::Uuid::new_v4();
+        chat.record_auto_review_launch_in_store(run_id, owner_session_id, None);
+
+        std::fs::write(repo_path.join("README.md"), "hello again").expect("update README");
+        git(&["add", "."]);
+        git(&["commit", "--quiet", "-m", "advance"]);
+        let completion_head = git_output(&["rev-parse", "HEAD"]);
+        assert_ne!(launch_head, completion_head);
+
+        chat.record_auto_review_completion_in_store(AutoReviewStoreCompletion {
+            run_id,
+            branch: "auto-review",
+            worktree_path: std::path::Path::new("/tmp/wt"),
+            terminal_status: AgentStatus::Completed,
+            has_findings: true,
+            findings: 1,
+            summary: Some("needs work"),
+            error: None,
+            agent_id: Some("agent-1"),
+            snapshot: None,
+            owner_session_id: Some(owner_session_id),
+            output: None,
+        });
+
+        let loaded = AutoReviewRunStore::open(repo_path).expect("reload store");
+        let run = loaded.get(run_id).expect("run loaded");
+        assert_eq!(run.head_at_launch.as_deref(), Some(launch_head.as_str()));
+    }
+
+    #[test]
     fn restart_reconciliation_surfaces_lost_auto_review_notice() {
         let _stub_lock = AUTO_STUB_LOCK.lock().unwrap();
         let code_home = tempfile::tempdir().expect("code home");
@@ -34362,7 +34425,8 @@ use code_core::protocol::OrderMeta;
         assert!(notice_present, "actionable findings should render a visible auto-review notice");
         let note = expect_post_turn_developer_input(&mut code_op_rx);
         assert!(note.contains("Background auto-review completed and reported 1 issue(s)"));
-        assert!(note.contains("Merge the worktree 'auto-review-branch'"));
+        assert!(note.contains("Treat this as a detached proposal"));
+        assert!(note.contains("re-validate the findings against the current workspace"));
         assert_no_code_ops_pending(&mut code_op_rx);
     }
 
@@ -34438,8 +34502,8 @@ use code_core::protocol::OrderMeta;
             "idle auto-review findings should remain cached for local diagnostics"
         );
         assert!(
-            history_contains_text(chat, "Auto Review: 1 issue(s) found. needs work Merge /tmp/wt to apply fixes."),
-            "visible notice should include the concise merge hint"
+            history_contains_text(chat, "Detached proposal at /tmp/wt; re-validate against current HEAD before merging."),
+            "visible notice should avoid direct merge guidance for detached auto-review worktrees"
         );
         let note = expect_post_turn_developer_input(&mut code_op_rx);
         assert!(note.contains("Background auto-review completed and reported 1 issue(s)"));
@@ -35270,9 +35334,12 @@ use code_core::protocol::OrderMeta;
 
         assert!(chat.pending_agent_notes.is_empty());
         assert!(chat.pending_dispatched_user_messages.is_empty());
-        assert!(!history_contains_text(chat, "Merge /tmp/wt to apply fixes."));
+        assert!(!history_contains_text(
+            chat,
+            "Detached proposal at /tmp/wt; re-validate against current HEAD before merging."
+        ));
         let note = expect_post_turn_developer_input(&mut code_op_rx);
-        assert!(note.contains("Merge the worktree 'auto-review-branch'"));
+        assert!(note.contains("Treat this as a detached proposal"));
         assert!(chat.bottom_pane.is_task_running());
         assert!(chat.deferred_auto_review_notice_lines.is_some());
         let developer_seen = chat.history_cells.iter().any(|cell| {
@@ -35292,7 +35359,7 @@ use code_core::protocol::OrderMeta;
         chat.active_task_ids.clear();
         chat.maybe_hide_spinner();
 
-        assert!(history_contains_text(chat, "Merge /tmp/wt to apply fixes."));
+        assert!(history_contains_text(chat, "Detached proposal at /tmp/wt; re-validate against current HEAD before merging."));
         assert_no_code_ops_pending(&mut code_op_rx);
     }
 
@@ -35347,7 +35414,7 @@ use code_core::protocol::OrderMeta;
             "idle observe path should not auto-start a hidden follow-up turn"
         );
         assert!(history_contains_text(chat, "Auto Review: 1 issue(s) found"));
-        assert!(history_contains_text(chat, "Merge /tmp/wt to apply fixes."));
+        assert!(history_contains_text(chat, "Detached proposal at /tmp/wt; re-validate against current HEAD before merging."));
         let note = expect_post_turn_developer_input(&mut code_op_rx);
         assert!(note.contains("Background auto-review completed and reported 1 issue(s)"));
         assert!(
@@ -35704,7 +35771,10 @@ use code_core::protocol::OrderMeta;
         assert!(history_contains_text(chat, "Auto Review: superseded result archived"));
         assert!(history_contains_text(chat, "1 issue(s) found"));
         assert!(history_contains_text(chat, "snap-stale"));
-        assert!(!history_contains_text(chat, "Merge /tmp/current-wt to apply fixes."));
+        assert!(!history_contains_text(
+            chat,
+            "Detached proposal at /tmp/current-wt; re-validate against current HEAD before merging."
+        ));
         assert_no_code_ops_pending(&mut code_op_rx);
     }
 
@@ -36085,9 +36155,13 @@ use code_core::protocol::OrderMeta;
         assert!(chat.background_review.is_none());
         assert!(chat.processed_auto_review_agents.contains_key("agent-current"));
         assert!(history_contains_text(chat, "Auto Review: 1 issue(s) found"));
-        assert!(history_contains_text(chat, "Merge /tmp/current-wt to apply fixes."));
+        assert!(history_contains_text(
+            chat,
+            "Detached proposal at /tmp/current-wt; re-validate against current HEAD before merging."
+        ));
         let note = expect_post_turn_developer_input(&mut code_op_rx);
         assert!(note.contains("Background auto-review completed and reported 1 issue(s)"));
+        assert!(note.contains("Treat this as a detached proposal"));
     }
 
     #[test]
@@ -36209,7 +36283,10 @@ use code_core::protocol::OrderMeta;
         assert!(history_contains_text(chat, "Auto Review: superseded result archived"));
         assert!(history_contains_text(chat, "1 issue(s) found"));
         assert!(history_contains_text(chat, "stale findings"));
-        assert!(!history_contains_text(chat, "Merge /tmp/stale-wt to apply fixes."));
+        assert!(!history_contains_text(
+            chat,
+            "Detached proposal at /tmp/stale-wt; re-validate against current HEAD before merging."
+        ));
         assert_no_code_ops_pending(&mut code_op_rx);
     }
 
@@ -36382,7 +36459,7 @@ use code_core::protocol::OrderMeta;
         let chat = harness.chat();
 
         chat.deferred_auto_review_notice_lines = Some(vec![
-            "Auto Review: 1 issue(s) found. summary Merge /tmp/wt to apply fixes. [Ctrl+A] Show"
+            "Auto Review: 1 issue(s) found. summary Detached proposal at /tmp/wt; re-validate against current HEAD before merging. [Ctrl+A] Show"
                 .to_string(),
         ]);
         chat.bottom_pane.set_task_running(false);
@@ -36392,7 +36469,7 @@ use code_core::protocol::OrderMeta;
 
         assert!(history_contains_text(
             chat,
-            "Auto Review: 1 issue(s) found. summary Merge /tmp/wt to apply fixes."
+            "Auto Review: 1 issue(s) found. summary Detached proposal at /tmp/wt; re-validate against current HEAD before merging."
         ));
         assert!(chat.deferred_auto_review_notice_lines.is_none());
     }
@@ -36446,7 +36523,10 @@ use code_core::protocol::OrderMeta;
             pending_before_review,
             "background review completion should not start a hidden turn"
         );
-        assert!(history_contains_text(chat, "Auto Review: 1 issue(s) found. summary Merge /tmp/wt to apply fixes."));
+        assert!(history_contains_text(
+            chat,
+            "Auto Review: 1 issue(s) found. summary Detached proposal at /tmp/wt; re-validate against current HEAD before merging."
+        ));
         let note = expect_post_turn_developer_input(&mut code_op_rx);
         assert!(note.contains("Background auto-review completed and reported 1 issue(s)"));
         assert!(!chat.is_task_running(), "background review should not hold task-running state");
@@ -41661,6 +41741,18 @@ impl ChatWidget<'_> {
         .map(PathBuf::from)
     }
 
+    fn auto_review_current_head(&self) -> Option<String> {
+        self.run_git_command(["rev-parse", "HEAD"], |stdout| {
+            let head = stdout.lines().next().unwrap_or("").trim();
+            if head.is_empty() {
+                Err("auto review HEAD unavailable".to_string())
+            } else {
+                Ok(head.to_string())
+            }
+        })
+        .ok()
+    }
+
     fn auto_review_baseline_path(&self) -> Option<PathBuf> {
         let git_root = self.auto_review_git_root()?;
         match auto_review_baseline_path_for_repo(&git_root) {
@@ -42686,10 +42778,12 @@ impl ChatWidget<'_> {
         owner_session_id: Uuid,
         base_snapshot: Option<&GhostCommit>,
     ) {
+        let head_at_launch = self.auto_review_current_head();
         self.update_auto_review_store(run_id, |run, now| {
             run.source = AutoReviewRunSource::Tui;
             run.owner_session_id = Some(owner_session_id);
             run.base_commit = base_snapshot.map(|base| base.id().to_string());
+            run.head_at_launch = run.head_at_launch.clone().or(head_at_launch.clone());
             run.model = Some(self.config.auto_review_model.clone());
             run.reasoning_effort = Some(self.config.auto_review_model_reasoning_effort.to_string());
             run.freshness = AutoReviewFreshness::Current;
@@ -42707,6 +42801,7 @@ impl ChatWidget<'_> {
         snapshot: Option<&str>,
         owner_session_id: Option<Uuid>,
     ) {
+        let head_at_launch = self.auto_review_current_head();
         self.update_auto_review_store(run_id, |run, now| {
             run.source = AutoReviewRunSource::Tui;
             if let Some(owner_session_id) = owner_session_id {
@@ -42719,6 +42814,7 @@ impl ChatWidget<'_> {
                 run.worktree_path = Some(worktree_path.to_path_buf());
             }
             run.snapshot_commit = snapshot.map(str::to_string).or_else(|| run.snapshot_commit.clone());
+            run.head_at_launch = run.head_at_launch.clone().or(head_at_launch.clone());
             run.model = Some(self.config.auto_review_model.clone());
             run.reasoning_effort = Some(self.config.auto_review_model_reasoning_effort.to_string());
             run.freshness = AutoReviewFreshness::Current;
@@ -43306,10 +43402,21 @@ impl ChatWidget<'_> {
         }
         if has_path {
             line.push(' ');
-            line.push_str(&format!("Merge {path_text} to apply fixes."));
+            if Self::is_detached_auto_review_branch(branch) {
+                line.push_str(&format!(
+                    "Detached proposal at {path_text}; re-validate against current HEAD before merging."
+                ));
+            } else {
+                line.push_str(&format!("Merge {path_text} to apply fixes."));
+            }
         }
         line.push_str(" [Ctrl+A] Show");
         line
+    }
+
+    fn is_detached_auto_review_branch(branch: &str) -> bool {
+        let branch = branch.trim();
+        branch == "auto-review" || branch.starts_with("auto-review-")
     }
 
     fn auto_review_superseded_notice_line(
@@ -43952,8 +44059,17 @@ impl ChatWidget<'_> {
             )
         } else if has_findings {
             self.last_auto_review_failure = None;
+            let next_step = if Self::is_detached_auto_review_branch(&worktree_label) {
+                format!(
+                    "Next: Treat this as a detached proposal. Re-validate the findings against the current workspace before merging '{worktree_label}' or cherry-picking selectively. If the current HEAD already fixes the issue, do not merge this worktree."
+                )
+            } else {
+                format!(
+                    "Next: Decide if the findings are genuine. If yes, Merge the worktree '{worktree_label}' to apply the changes (or cherry-pick selectively). If not, do not merge."
+                )
+            };
             let mut note = format!(
-                "[developer] {}\n\nBackground auto-review completed and reported {effective_findings} issue(s).\n\nA separate LLM ran /review (and may have run auto-resolve) in an isolated git worktree. Any proposed fixes live only in that worktree until you merge them.\n\nNext: Decide if the findings are genuine. If yes, Merge the worktree '{worktree_label}' to apply the changes (or cherry-pick selectively). If not, do not merge.\n\nWorktree path: {worktree_path_label}\n{snapshot_note}\n{agent_note}",
+                "[developer] {}\n\nBackground auto-review completed and reported {effective_findings} issue(s).\n\nA separate LLM ran /review (and may have run auto-resolve) in an isolated git worktree. Any proposed fixes live only in that worktree until you merge them.\n\n{next_step}\n\nWorktree path: {worktree_path_label}\n{snapshot_note}\n{agent_note}",
                 notice_line.as_deref().unwrap_or("Background auto-review found issues."),
             );
             if let Some(summary_note) = summary_note {


### PR DESCRIPTION
## Summary
- add explicit auto-review target applicability to the compact ledger alongside freshness
- preserve launch HEAD metadata and avoid treating completion-time HEAD as the reviewed target
- label detached auto-review worktrees as proposals that require re-validation before merging across TUI and exec output

Fixes #374

## Validation
- cargo test --manifest-path code-rs/Cargo.toml -p code-core compact_ledger
- cargo test --manifest-path code-rs/Cargo.toml -p code-tui auto_review
- ./build-fast.sh

## Review
- planning agents: code-gpt-5.5, claude-sonnet-4.6, antigravity
- final review agents: code-gpt-5.5, claude-sonnet-4.6, antigravity; no blockers