### PR TITLE
Add git patch exec harness safety scenarios

### DIFF
--- a/tools/code-exec-harness/README.md
+++ b/tools/code-exec-harness/README.md
@@ -95,6 +95,11 @@ Scenarios are JSON files. Common fields:
   auth still applies.
 - `expect`: simple assertions over the final answer, commands, fake `gh` calls,
   and exit code
+- `expect.workspace_files`: assertions over files in the isolated workspace after
+  the run, including `exists`, `equals`, `contains`, `contains_all`, and
+  `not_contains`
+- `expect.workspace_git_status`: assertions over `git status --porcelain` in the
+  isolated workspace, including `equals`, `contains_all`, and `not_contains`
 
 The harness is intentionally black-box: the unit under test is the real `code
 exec` binary and its emitted JSONL stream.

--- a/tools/code-exec-harness/harness.py
+++ b/tools/code-exec-harness/harness.py
@@ -802,6 +802,78 @@ def request_assertion_target(request: dict[str, Any], assertion: dict[str, Any])
     raise HarnessError(f"unsupported responses assertion scope: {scope}")
 
 
+def workspace_root_from_summary(summary: dict[str, Any]) -> Path:
+    run_dir = summary.get("run_dir")
+    if not isinstance(run_dir, str):
+        raise HarnessError("summary is missing run_dir")
+    return Path(run_dir) / "workspace"
+
+
+def workspace_path_from_summary(summary: dict[str, Any], relative_path: str) -> Path:
+    path = Path(relative_path)
+    if path.is_absolute() or ".." in path.parts:
+        raise HarnessError(f"workspace file expectation path must be relative: {relative_path}")
+    return workspace_root_from_summary(summary) / path
+
+
+def workspace_file_expectation_failures(summary: dict[str, Any], assertion: dict[str, Any]) -> list[str]:
+    relative_path = str(assertion.get("path", ""))
+    if not relative_path:
+        return ["workspace_files expectation is missing path"]
+    try:
+        path = workspace_path_from_summary(summary, relative_path)
+    except HarnessError as exc:
+        return [str(exc)]
+
+    expected_exists = assertion.get("exists")
+    if expected_exists is not None and path.exists() != bool(expected_exists):
+        return [f"workspace file {relative_path!r} exists expected {bool(expected_exists)}, got {path.exists()}"]
+    if not path.exists():
+        return []
+    if not path.is_file():
+        return [f"workspace path {relative_path!r} is not a file"]
+
+    contents = read_text(path)
+    failures = []
+    if "equals" in assertion and contents != str(assertion["equals"]):
+        failures.append(f"workspace file {relative_path!r} did not equal expected contents")
+    if "contains" in assertion and str(assertion["contains"]) not in contents:
+        failures.append(f"workspace file {relative_path!r} did not contain {assertion['contains']!r}")
+    for needle in assertion.get("contains_all", []):
+        if str(needle) not in contents:
+            failures.append(f"workspace file {relative_path!r} did not contain {needle!r}")
+    if "not_contains" in assertion and str(assertion["not_contains"]) in contents:
+        failures.append(f"workspace file {relative_path!r} unexpectedly contained {assertion['not_contains']!r}")
+    return failures
+
+
+def workspace_git_status_failures(summary: dict[str, Any], assertion: dict[str, Any]) -> list[str]:
+    try:
+        workspace = workspace_root_from_summary(summary)
+    except HarnessError as exc:
+        return [str(exc)]
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workspace,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    status = result.stdout
+    if result.returncode != 0:
+        return [f"git status failed in harness workspace: {result.stderr.strip()}"]
+    failures = []
+    if "equals" in assertion and status != str(assertion["equals"]):
+        failures.append("workspace git status did not equal expected output")
+    for needle in assertion.get("contains_all", []):
+        if str(needle) not in status:
+            failures.append(f"workspace git status did not contain {needle!r}")
+    if "not_contains" in assertion and str(assertion["not_contains"]) in status:
+        failures.append(f"workspace git status unexpectedly contained {assertion['not_contains']!r}")
+    return failures
+
+
 def request_input_items(request: dict[str, Any]) -> list[dict[str, Any]]:
     body = request.get("body")
     if not isinstance(body, dict):
@@ -964,6 +1036,16 @@ def assert_expectations(summary: dict[str, Any], scenario: dict[str, Any]) -> li
         expected = int(expect["responses_request_count"])
         if actual != expected:
             failures.append(f"responses request count expected {expected}, got {actual}")
+    for assertion in expect.get("workspace_files", []):
+        if not isinstance(assertion, dict):
+            failures.append("workspace_files expectation entries must be objects")
+            continue
+        failures.extend(workspace_file_expectation_failures(summary, assertion))
+    for assertion in expect.get("workspace_git_status", []):
+        if not isinstance(assertion, dict):
+            failures.append("workspace_git_status expectation entries must be objects")
+            continue
+        failures.extend(workspace_git_status_failures(summary, assertion))
     for assertion in expect.get("command_events", []):
         if not isinstance(assertion, dict):
             failures.append("command_events expectation entries must be objects")

--- a/tools/code-exec-harness/run-deterministic.sh
+++ b/tools/code-exec-harness/run-deterministic.sh
@@ -16,9 +16,11 @@ fi
 
 scenarios=(
   "$ROOT_DIR/tools/code-exec-harness/scenarios/context-ledger-request-summary.json"
+  "$ROOT_DIR/tools/code-exec-harness/scenarios/exec-apply-patch-roundtrip.json"
   "$ROOT_DIR/tools/code-exec-harness/scenarios/exec-basic-smoke.json"
   "$ROOT_DIR/tools/code-exec-harness/scenarios/exec-readonly-write-denied.json"
   "$ROOT_DIR/tools/code-exec-harness/scenarios/exec-shell-command-roundtrip.json"
+  "$ROOT_DIR/tools/code-exec-harness/scenarios/exec-workspace-write-edit.json"
   "$ROOT_DIR/tools/code-exec-harness/scenarios/image-history-replay.json"
   "$ROOT_DIR/tools/code-exec-harness/scenarios/manual-skill-explicit-invocation.json"
   "$ROOT_DIR/tools/code-exec-harness/scenarios/manual-skill-not-implicit.json"

--- a/tools/code-exec-harness/scenarios/exec-apply-patch-roundtrip.json
+++ b/tools/code-exec-harness/scenarios/exec-apply-patch-roundtrip.json
@@ -1,0 +1,94 @@
+{
+    "name": "exec-apply-patch-roundtrip",
+    "model": "gpt-5.1-codex",
+    "sandbox": "workspace-write",
+    "files": {
+        "notes.txt": "before\n"
+    },
+    "prompt": "Use apply_patch to change notes.txt from before to after, then reply with exactly: patch done",
+    "responses_api": {
+        "responses": [
+            {
+                "response_id": "resp-patch-call",
+                "events": [
+                    {
+                        "type": "response.created",
+                        "payload": {
+                            "type": "response.created",
+                            "response": {
+                                "id": "resp-patch-call"
+                            }
+                        }
+                    },
+                    {
+                        "item": {
+                            "type": "function_call",
+                            "call_id": "call-apply-patch",
+                            "name": "shell_command",
+                            "arguments": "{\"command\":\"apply_patch <<'PATCH'\\n*** Begin Patch\\n*** Update File: notes.txt\\n@@\\n-before\\n+after\\n*** End Patch\\nPATCH\",\"login\":false,\"timeout_ms\":1000}"
+                        }
+                    }
+                ]
+            },
+            {
+                "response_id": "resp-patch-final",
+                "events": [
+                    {
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "id": "msg-patch-final",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "patch done"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "expect": {
+        "returncode": 0,
+        "assistant_contains": [
+            "patch done"
+        ],
+        "responses_request_count": 2,
+        "workspace_files": [
+            {
+                "path": "notes.txt",
+                "exists": true,
+                "equals": "after\n"
+            }
+        ],
+        "workspace_git_status": [
+            {
+                "equals": " M notes.txt\n"
+            }
+        ],
+        "event_count_any": [
+            {
+                "item.file_change": 2,
+                "item.agent_message": 1,
+                "turn.completed": 1
+            }
+        ],
+        "function_call_outputs": [
+            {
+                "request": 1,
+                "call_id": "call-apply-patch",
+                "contains_all": [
+                    "Success"
+                ],
+                "contains_any": [
+                    "\"exit_code\":0",
+                    "Exit code: 0"
+                ]
+            }
+        ]
+    },
+    "max_seconds": 30,
+    "timeout_seconds": 90
+}

--- a/tools/code-exec-harness/scenarios/exec-workspace-write-edit.json
+++ b/tools/code-exec-harness/scenarios/exec-workspace-write-edit.json
@@ -1,47 +1,47 @@
 {
-    "name": "exec-readonly-write-denied",
+    "name": "exec-workspace-write-edit",
     "model": "gpt-5.1-codex",
-    "sandbox": "read-only",
+    "sandbox": "workspace-write",
     "files": {
-        "README.md": "# Read-only write denial fixture\n"
+        "README.md": "# Workspace write fixture\n"
     },
-    "prompt": "Try to create blocked.txt in the workspace, then reply with exactly: write denied",
+    "prompt": "Create edited.txt containing harness-edit-ok, then reply with exactly: edit done",
     "responses_api": {
         "responses": [
             {
-                "response_id": "resp-write-call",
+                "response_id": "resp-edit-call",
                 "events": [
                     {
                         "type": "response.created",
                         "payload": {
                             "type": "response.created",
                             "response": {
-                                "id": "resp-write-call"
+                                "id": "resp-edit-call"
                             }
                         }
                     },
                     {
                         "item": {
                             "type": "function_call",
-                            "call_id": "call-write-denied",
+                            "call_id": "call-edit-file",
                             "name": "shell_command",
-                            "arguments": "{\"command\":\"printf denied > blocked.txt\",\"login\":false,\"timeout_ms\":1000}"
+                            "arguments": "{\"command\":\"printf 'harness-edit-ok\\n' > edited.txt\",\"login\":false,\"timeout_ms\":1000}"
                         }
                     }
                 ]
             },
             {
-                "response_id": "resp-write-final",
+                "response_id": "resp-edit-final",
                 "events": [
                     {
                         "item": {
                             "type": "message",
                             "role": "assistant",
-                            "id": "msg-write-final",
+                            "id": "msg-edit-final",
                             "content": [
                                 {
                                     "type": "output_text",
-                                    "text": "write denied"
+                                    "text": "edit done"
                                 }
                             ]
                         }
@@ -53,13 +53,19 @@
     "expect": {
         "returncode": 0,
         "assistant_contains": [
-            "write denied"
+            "edit done"
         ],
         "responses_request_count": 2,
         "workspace_files": [
             {
-                "path": "blocked.txt",
-                "exists": false
+                "path": "edited.txt",
+                "exists": true,
+                "equals": "harness-edit-ok\n"
+            }
+        ],
+        "workspace_git_status": [
+            {
+                "equals": "?? edited.txt\n"
             }
         ],
         "event_count_any": [
@@ -77,32 +83,20 @@
         ],
         "command_events": [
             {
-                "command_contains": "blocked.txt",
+                "command_contains": "edited.txt",
                 "status_any": [
                     "started",
-                    "failed"
-                ]
-            },
-            {
-                "status_any": [
-                    "output",
-                    "failed"
-                ],
-                "output_contains": [
-                    "operation not permitted"
+                    "completed"
                 ]
             }
         ],
         "function_call_outputs": [
             {
                 "request": 1,
-                "call_id": "call-write-denied",
-                "contains_all": [
-                    "operation not permitted"
-                ],
+                "call_id": "call-edit-file",
                 "contains_any": [
-                    "\"exit_code\":1",
-                    "Exit code: 1"
+                    "\"exit_code\":0",
+                    "Exit code: 0"
                 ]
             }
         ]


### PR DESCRIPTION
## Summary

- add workspace file-content and git-status assertions to `tools/code-exec-harness`
- add deterministic fake Responses scenarios for `apply_patch` round-trip and workspace-write file edits
- extend the read-only write-denial scenario to prove the denied file is not created
- include the new scenarios in `just harness-smoke`

Refs #410.

## Validation

- `./build-fast.sh`
- `just harness-smoke`
- `git diff --check`
- JSON parse checks for the changed scenario files

## Review Notes

A scoped Claude review was attempted after validation. Two launches failed because the agent manager only accepted context files under `/Users/cbusillo/Developer/code`; a third path-inspection review returned findings from an impossible/wrong checkout state, claiming files and helpers were deleted. Manual verification showed the claimed deletions were false: `exec-basic-smoke.json`, `exec-readonly-write-denied.json`, `exec-shell-command-roundtrip.json`, `README.md`, `AGENTS.md`, `run-deterministic.sh`, `shlex.quote`, `code_exec_supports_option`, summary `events`, and the command/function-output assertion helpers are all present. The branch was therefore reviewed manually against the actual diff and validated with the full deterministic harness suite.
