### PR TITLE
Add local code rebuild preflight check

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -26,7 +26,8 @@ source "$HOME/.cargo/env"
 # Build everything (CLI, TUI, MCP servers). This is the same check CI runs.
 ./build-fast.sh
 
-# Install the PATH-resolved local binary and launch the TUI.
+# Preview PATH/release-bin wiring, then install the PATH-resolved local binary.
+just local-code-rebuild-preflight
 just local-code-rebuild
 code -- "explain this codebase to me"
 ```

--- a/docs/upstream-import-policy.md
+++ b/docs/upstream-import-policy.md
@@ -241,10 +241,19 @@ git status --short --branch
 Install and smoke-check the local binary before tagging:
 
 ```sh
+just local-code-rebuild-preflight
 just local-code-rebuild
 code --version
 code exec -m gpt-5.5 --sandbox read-only --max-seconds 30 "Reply with exactly OK."
 ```
+
+`just local-code-rebuild-preflight` does not build or mutate files. It prints
+the current PATH entry, the release binary target, whether the release binary is
+a symlink that would be restored after a failed rebuild, and a `SAFE` or
+`WARNING` verdict for the local dogfood command wiring. Use
+`just local-code-rebuild-preflight-check` to run deterministic temp-directory
+fixtures for this preflight path without touching the real PATH-resolved
+`code` command.
 
 Run `just local-code-rebuild` after any release-readiness `./build-fast.sh` run:
 the fast build creates dev-fast artifacts for validation, while the rebuild

--- a/justfile
+++ b/justfile
@@ -68,6 +68,14 @@ local-code-rebuild:
     ./scripts/local/rebuild-path-code.sh
 
 [no-cd]
+local-code-rebuild-preflight:
+    ./scripts/local/rebuild-path-code.sh --preflight
+
+[no-cd]
+local-code-rebuild-preflight-check:
+    ./scripts/local/check-code-rebuild-preflight.sh
+
+[no-cd]
 local-remove-homebrew-code-link:
     ./scripts/local/remove-homebrew-code-link.sh
 

--- a/scripts/local/check-code-rebuild-preflight.sh
+++ b/scripts/local/check-code-rebuild-preflight.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/local/rebuild-path-code.sh"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/code-rebuild-preflight.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/repo/code-rs/target/release" "$tmp/bin" "$tmp/external-target/release"
+release_bin="$tmp/repo/code-rs/target/release/code"
+external_bin="$tmp/external-target/release/code"
+
+write_fake_code() {
+	local path="$1"
+	local label="$2"
+	mkdir -p "$(dirname "$path")"
+	cat >"$path" <<EOF
+#!/usr/bin/env bash
+echo "$label"
+EOF
+	chmod +x "$path"
+}
+
+run_preflight() {
+	local output="$1"
+	shift
+	set +e
+	CODE_LOCAL_REBUILD_CODE_RS_ROOT="$tmp/repo/code-rs" \
+		CODE_LOCAL_REBUILD_RELEASE_BIN="$release_bin" \
+		CARGO_TARGET_DIR="$tmp/external-target" \
+		PATH="$tmp/bin:$PATH" \
+		"$script" --preflight "$@" >"$output" 2>&1
+	local status="$?"
+	set -e
+	return "$status"
+}
+
+assert_contains() {
+	local file="$1"
+	local expected="$2"
+	if ! grep -Fq "$expected" "$file"; then
+		echo "error: expected output to contain: $expected" >&2
+		echo "--- output ---" >&2
+		cat "$file" >&2
+		exit 1
+	fi
+}
+
+assert_not_exists() {
+	local path="$1"
+	if [[ -e "$path" || -L "$path" ]]; then
+		echo "error: preflight unexpectedly created or modified $path" >&2
+		exit 1
+	fi
+}
+
+write_fake_code "$external_bin" "external target code"
+ln -s "$external_bin" "$release_bin"
+ln -s "$release_bin" "$tmp/bin/code"
+matching_output="$tmp/matching.out"
+run_preflight "$matching_output"
+assert_contains "$matching_output" "Local code rebuild preflight"
+assert_contains "$matching_output" "Release bin is a symlink: $release_bin -> $external_bin"
+assert_contains "$matching_output" "restore it if the build failed"
+assert_contains "$matching_output" "SAFE: PATH resolves to the local release binary."
+
+rm -f "$tmp/bin/code"
+write_fake_code "$tmp/bin/code" "unrelated path code"
+mismatch_output="$tmp/mismatch.out"
+if run_preflight "$mismatch_output"; then
+	echo "error: mismatched PATH preflight unexpectedly succeeded" >&2
+	exit 1
+fi
+assert_contains "$mismatch_output" "WARNING: PATH does not resolve to the freshly built binary"
+assert_contains "$mismatch_output" "External target dir is active"
+
+missing_release="$tmp/missing/release/code"
+missing_output="$tmp/missing.out"
+release_bin="$missing_release"
+if run_preflight "$missing_output"; then
+	echo "error: missing release-bin preflight unexpectedly succeeded with unrelated PATH code" >&2
+	exit 1
+fi
+assert_contains "$missing_output" "Release bin does not exist yet and would be created by cargo build."
+assert_not_exists "$missing_release"
+
+missing_path_output="$tmp/missing-path.out"
+empty_path="$tmp/empty-path"
+mkdir -p "$empty_path"
+set +e
+CODE_LOCAL_REBUILD_CODE_RS_ROOT="$tmp/repo/code-rs" \
+	CODE_LOCAL_REBUILD_RELEASE_BIN="$release_bin" \
+	CARGO_TARGET_DIR="$tmp/external-target" \
+	PATH="$empty_path:/usr/bin:/bin" \
+	"$script" --preflight >"$missing_path_output" 2>&1
+missing_path_status="$?"
+set -e
+if [[ "$missing_path_status" -ne 1 ]]; then
+	echo "error: missing PATH preflight expected exit 1, got $missing_path_status" >&2
+	cat "$missing_path_output" >&2
+	exit 1
+fi
+assert_contains "$missing_path_output" "NOT SAFE: could not find 'code' on PATH"
+
+echo "code rebuild preflight checks passed"

--- a/scripts/local/rebuild-path-code.sh
+++ b/scripts/local/rebuild-path-code.sh
@@ -2,19 +2,120 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-code_rs_root="$repo_root/code-rs"
-release_bin="$code_rs_root/target/release/code"
+code_rs_root="${CODE_LOCAL_REBUILD_CODE_RS_ROOT:-$repo_root/code-rs}"
+release_bin="${CODE_LOCAL_REBUILD_RELEASE_BIN:-$code_rs_root/target/release/code}"
 cargo_target_dir="${CARGO_TARGET_DIR:-$code_rs_root/target}"
 if [[ "$cargo_target_dir" != /* ]]; then
 	cargo_target_dir="$(pwd)/$cargo_target_dir"
 fi
 cargo_release_bin="$cargo_target_dir/release/code"
+preflight=0
 
 resolve_code_version() {
 	tr -d '[:space:]' <"$repo_root/VERSION"
 }
 
 code_version="${CODE_VERSION:-$(resolve_code_version || true)}"
+
+usage() {
+	cat <<USAGE
+Usage: scripts/local/rebuild-path-code.sh [--preflight]
+
+Build the release binary that the PATH-resolved local 'code' command should use.
+
+Options:
+  --preflight  Print the current PATH/release-bin wiring and safety decisions
+               without building, deleting, or replacing anything.
+  --dry-run    Alias for --preflight.
+  -h, --help   Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--preflight | --dry-run)
+		preflight=1
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "error: unknown option: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+	shift
+done
+
+real_path() {
+	python3 - "$1" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
+print_path_wiring() {
+	local path_code="$1"
+	local resolved_path=""
+	local resolved_release_bin=""
+
+	if [[ -n "$path_code" ]]; then
+		resolved_path="$(real_path "$path_code")"
+	fi
+	resolved_release_bin="$(real_path "$release_bin")"
+
+	echo
+	echo "PATH entry:   ${path_code:-<missing>}"
+	if [[ -n "$path_code" ]]; then
+		echo "Resolves to:  $resolved_path"
+	fi
+	echo "Release bin:  $release_bin"
+	echo "Release real: $resolved_release_bin"
+
+	if [[ -z "$path_code" ]]; then
+		echo "NOT SAFE: could not find 'code' on PATH" >&2
+		return 1
+	fi
+
+	if [[ "$resolved_path" != "$release_bin" && "$resolved_path" != "$resolved_release_bin" ]]; then
+		echo "WARNING: PATH does not resolve to the freshly built binary" >&2
+		return 2
+	fi
+
+	echo "SAFE: PATH resolves to the local release binary."
+	return 0
+}
+
+path_code="$(command -v code || true)"
+
+if [[ "$preflight" -eq 1 ]]; then
+	echo "Local code rebuild preflight"
+	echo "Repo root:    $repo_root"
+	echo "Code root:    $code_rs_root"
+	echo "Target dir:   $cargo_target_dir"
+	echo "Cargo bin:    $cargo_release_bin"
+	if [[ -L "$release_bin" ]]; then
+		echo "Release bin is a symlink: $release_bin -> $(readlink "$release_bin")"
+		echo "A rebuild would replace it during cargo build and restore it if the build failed."
+	elif [[ -e "$release_bin" ]]; then
+		echo "Release bin is an existing file and would be replaced by cargo build."
+	else
+		echo "Release bin does not exist yet and would be created by cargo build."
+	fi
+	if [[ "$cargo_release_bin" != "$release_bin" ]]; then
+		echo "External target dir is active; a successful rebuild would link $release_bin -> $cargo_release_bin."
+	fi
+	set +e
+	print_path_wiring "$path_code"
+	status="$?"
+	set -e
+	if [[ "$status" -eq 2 ]]; then
+		exit 2
+	fi
+	exit "$status"
+fi
 
 removed_release_symlink_target=""
 restore_release_symlink_on_error() {
@@ -50,33 +151,17 @@ if [[ "$cargo_release_bin" != "$release_bin" ]]; then
 	echo "Updated release-bin symlink for external target dir: $release_bin -> $cargo_release_bin"
 fi
 
-path_code="$(command -v code || true)"
-if [[ -z "$path_code" ]]; then
-	echo "error: could not find 'code' on PATH" >&2
+set +e
+print_path_wiring "$path_code"
+wiring_status="$?"
+set -e
+if [[ "$wiring_status" -eq 1 ]]; then
 	exit 1
 fi
 
-resolved_path="$(
-	python3 - "$path_code" <<'PY'
-import os, sys
-print(os.path.realpath(sys.argv[1]))
-PY
-)"
-resolved_release_bin="$(
-	python3 - "$release_bin" <<'PY'
-import os, sys
-print(os.path.realpath(sys.argv[1]))
-PY
-)"
-
-echo
-echo "PATH entry:   $path_code"
-echo "Resolves to:  $resolved_path"
-echo "Release bin:  $release_bin"
-
-if [[ "$resolved_path" != "$release_bin" && "$resolved_path" != "$resolved_release_bin" ]]; then
-	echo "warning: PATH does not resolve to the freshly built binary" >&2
+ls -l "$release_bin"
+if [[ "$wiring_status" -eq 0 ]]; then
+	"$path_code" --version
+else
+	echo "Skipping PATH 'code --version' because PATH does not resolve to the rebuilt binary." >&2
 fi
-
-stat -f 'Updated: %Sm %N' "$release_bin"
-"$path_code" --version


### PR DESCRIPTION
## Summary

- add `scripts/local/rebuild-path-code.sh --preflight` / `--dry-run` to inspect PATH and release-bin wiring without building or mutating files
- add `just local-code-rebuild-preflight` and a deterministic temp-fixture `just local-code-rebuild-preflight-check`
- document the preflight before local rebuild/install flows
- avoid false confidence by skipping `PATH code --version` after rebuild when PATH does not resolve to the rebuilt binary

Refs #412.

## Validation

- `just local-code-rebuild-preflight-check`
- `bash -n scripts/local/rebuild-path-code.sh scripts/local/check-code-rebuild-preflight.sh`
- `git diff --check --cached`
- `./build-fast.sh`
- `just harness-smoke`

## Review

A scoped read-only agent review found one blocking issue: after a successful rebuild with mismatched PATH, the script still ran `path_code --version`, which could verify an unrelated binary. This PR now gates that call on safe PATH wiring and prints a skip note otherwise. The review's low-friction suggestions were also handled: portable `ls -l`, documented `--dry-run`, and a missing-PATH fixture.
