### PR TITLE
Add Code Bridge app-server boundary fixture

### DIFF
--- a/code-rs/app-server/tests/suite/v2/code_bridge_boundary.rs
+++ b/code-rs/app-server/tests/suite/v2/code_bridge_boundary.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use app_test_support::McpProcess;
+use app_test_support::to_response;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::RemoteControlConnectionStatus;
+use codex_app_server_protocol::RemoteControlStatusReadResponse;
+use codex_app_server_protocol::RequestId;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn code_bridge_control_does_not_enter_desktop_remote_control_path() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    for method in ["codeBridge/control", "code_bridge/control"] {
+        let request_id = mcp
+            .send_raw_request(
+                method,
+                Some(json!({
+                    "id": "bridge-control-1",
+                    "action": "ping",
+                    "expectResult": false,
+                })),
+            )
+            .await?;
+
+        let error = timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+        )
+        .await??;
+        assert_eq!(error.error.code, -32600);
+        assert!(error.error.message.contains("Invalid request"));
+        assert!(error.error.message.contains(method));
+    }
+
+    let request_id = mcp
+        .send_raw_request("remoteControl/status/read", Some(json!({})))
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let payload: RemoteControlStatusReadResponse = to_response(response)?;
+
+    assert_eq!(payload.status, RemoteControlConnectionStatus::Disabled);
+    assert_eq!(payload.environment_id, None);
+    Ok(())
+}

--- a/code-rs/app-server/tests/suite/v2/mod.rs
+++ b/code-rs/app-server/tests/suite/v2/mod.rs
@@ -2,6 +2,7 @@ mod account;
 mod analytics;
 mod app_list;
 mod client_metadata;
+mod code_bridge_boundary;
 mod collaboration_mode_list;
 #[cfg(unix)]
 mod command_exec;

--- a/docs/code-bridge-browser-parity.md
+++ b/docs/code-bridge-browser-parity.md
@@ -11,6 +11,12 @@ Code Bridge is an Every Code overlay, not a Desktop compatibility mutation.
 Future bridge behavior should be additive and validated through bridge-specific
 fixtures before it touches app-server or TUI presentation code.
 
+When Codex CLI already has a similar app-server, protocol, or command surface,
+prefer aligning Every Code behavior with that Codex shape instead of making the
+Codex-facing surface mirror the old Every Code bridge commands. Preserve Every
+Code features, fixes, and fixtures through the smallest additive overlay needed
+for behavior that Codex does not already cover.
+
 Code Bridge `control` events must use a distinct transport or namespace from
 Codex Desktop remote-control requests. Fake bridge fixtures must prove that
 bridge control delivery does not route through Desktop remote-control status,
@@ -56,7 +62,9 @@ after local-page fixtures prove the lifecycle boundary.
 ## Validation Order
 
 1. Add fake bridge metadata/server fixtures that prove discovery, stale heartbeat
-   detection, subscription normalization, and control request/result matching.
+   detection, subscription normalization, and control request/result matching,
+   while first proving Code Bridge-shaped control does not enter the Codex
+   Desktop remote-control JSON-RPC path.
 2. Port the local navigation probe to the new overlay boundary using a local HTTP
    server and no external network.
 3. Add TUI snapshot coverage only after event schema and storage are stable.


### PR DESCRIPTION
## Summary

Updates #399.

- adds an app-server v2 boundary fixture proving Code Bridge-shaped control requests do not enter the Codex Desktop `remoteControl/*` JSON-RPC path
- verifies the existing `remoteControl/status/read` compatibility response remains upstream-shaped and disabled
- updates the Code Bridge parity boundary doc to prefer Codex-aligned app-server/protocol/command surfaces where Codex already has a similar shape

## Validation

- `cargo test -p codex-app-server --test all code_bridge_boundary -- --nocapture`
- `git diff --check`
- `./build-fast.sh`

## Notes

This intentionally does not add a new bridge crate or restore old Every Code bridge commands. It protects the app-server boundary first so later Code Bridge fixtures can remain additive and Codex-aligned.
