### PR TITLE
Add fake Code Bridge core fixtures

### DIFF
--- a/code-rs/core/src/code_bridge.rs
+++ b/code-rs/core/src/code_bridge.rs
@@ -1,0 +1,550 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::fs;
+use tokio::time::timeout;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+
+pub const META_FILE: &str = "code-bridge.json";
+pub const SUBSCRIPTION_FILE: &str = "code-bridge.subscription.json";
+pub const HEARTBEAT_STALE_MS: i64 = 20_000;
+
+const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
+const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(5);
+const CONTROL_FORWARDED_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeMeta {
+    pub url: String,
+    pub secret: String,
+    pub port: Option<u16>,
+    pub workspace_path: Option<String>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub heartbeat_at: Option<DateTime<Utc>>,
+    pub pid: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeTarget {
+    pub meta_path: PathBuf,
+    pub meta: BridgeMeta,
+    pub stale: bool,
+    pub heartbeat_age_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeSubscription {
+    #[serde(default = "default_levels")]
+    pub levels: Vec<String>,
+    #[serde(default = "default_capabilities")]
+    pub capabilities: Vec<String>,
+    #[serde(default = "default_filter", alias = "llm_filter")]
+    pub llm_filter: String,
+}
+
+impl Default for BridgeSubscription {
+    fn default() -> Self {
+        Self {
+            levels: default_levels(),
+            capabilities: default_capabilities(),
+            llm_filter: default_filter(),
+        }
+    }
+}
+
+impl BridgeSubscription {
+    pub fn normalized(mut self) -> Self {
+        self.levels = normalize_unique(self.levels);
+        self.capabilities = normalize_unique(self.capabilities);
+        self.llm_filter = self.llm_filter.trim().to_lowercase();
+        if self.llm_filter.is_empty() {
+            self.llm_filter = default_filter();
+        }
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BridgeClientMessage {
+    Auth {
+        role: BridgeRole,
+        secret: String,
+        client_id: String,
+    },
+    Subscribe {
+        levels: Vec<String>,
+        capabilities: Vec<String>,
+        #[serde(rename = "llmFilter")]
+        llm_filter: String,
+    },
+    ControlRequest(BridgeControlRequest),
+}
+
+impl BridgeClientMessage {
+    pub fn is_desktop_remote_control_message(&self) -> bool {
+        serde_json::to_value(self)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("method")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
+            .is_some_and(|method| method.starts_with("remoteControl/"))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum BridgeRole {
+    Consumer,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeControlRequest {
+    pub id: String,
+    pub action: BridgeControlAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expect_result: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum BridgeControlAction {
+    Ping,
+    Screenshot,
+    Javascript,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BridgeServerMessage {
+    AuthSuccess,
+    SubscribeAck,
+    ControlForwarded {
+        id: String,
+        delivered: usize,
+    },
+    ControlResult {
+        id: String,
+        ok: bool,
+        #[serde(default)]
+        result: Option<Value>,
+        #[serde(default)]
+        error: Option<Value>,
+    },
+    Screenshot {
+        id: String,
+        mime: String,
+        data: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BridgeControlOutcome {
+    pub delivered: usize,
+    pub ok: bool,
+    pub result: Option<Value>,
+    pub screenshot: Option<BridgeScreenshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeScreenshot {
+    pub mime: String,
+    pub data_len: usize,
+}
+
+pub async fn discover_bridge_targets(cwd: &Path) -> Result<Vec<BridgeTarget>> {
+    let mut targets = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut current = Some(cwd);
+
+    while let Some(dir) = current {
+        let candidate = dir.join(".code").join(META_FILE);
+        if seen.insert(candidate.clone()) && candidate.exists() {
+            let raw = fs::read_to_string(&candidate)
+                .await
+                .with_context(|| format!("read bridge metadata at {}", candidate.display()))?;
+            let meta: BridgeMeta = serde_json::from_str(&raw)
+                .with_context(|| format!("parse bridge metadata at {}", candidate.display()))?;
+            let (stale, heartbeat_age_ms) = compute_staleness(&meta, &candidate).await;
+            targets.push(BridgeTarget {
+                meta_path: candidate,
+                meta,
+                stale,
+                heartbeat_age_ms,
+            });
+        }
+        current = dir.parent();
+    }
+
+    Ok(targets)
+}
+
+pub async fn load_subscription(workspace: &Path) -> Result<BridgeSubscription> {
+    let path = workspace.join(".code").join(SUBSCRIPTION_FILE);
+    if !path.exists() {
+        return Ok(BridgeSubscription::default().normalized());
+    }
+
+    let raw = fs::read_to_string(&path)
+        .await
+        .with_context(|| format!("read bridge subscription at {}", path.display()))?;
+    let subscription: BridgeSubscription = serde_json::from_str(&raw)
+        .with_context(|| format!("parse bridge subscription at {}", path.display()))?;
+    Ok(subscription.normalized())
+}
+
+pub async fn request_control(
+    target: &BridgeTarget,
+    subscription: &BridgeSubscription,
+    request: BridgeControlRequest,
+    result_timeout: Duration,
+) -> Result<BridgeControlOutcome> {
+    let (mut ws, _) = connect_async(&target.meta.url)
+        .await
+        .with_context(|| format!("connect to bridge {}", target.meta.url))?;
+
+    let auth = BridgeClientMessage::Auth {
+        role: BridgeRole::Consumer,
+        secret: target.meta.secret.clone(),
+        client_id: client_id_for(target),
+    };
+    send_json(&mut ws, &auth).await.context("send bridge auth")?;
+    wait_for_server_message(
+        &mut ws,
+        |message| matches!(message, BridgeServerMessage::AuthSuccess),
+        AUTH_TIMEOUT,
+    )
+    .await
+    .context("wait for bridge auth success")?;
+
+    let subscription = subscription.clone().normalized();
+    let subscribe = BridgeClientMessage::Subscribe {
+        levels: subscription.levels,
+        capabilities: subscription.capabilities,
+        llm_filter: subscription.llm_filter,
+    };
+    send_json(&mut ws, &subscribe)
+        .await
+        .context("send bridge subscribe")?;
+    wait_for_server_message(
+        &mut ws,
+        |message| matches!(message, BridgeServerMessage::SubscribeAck),
+        SUBSCRIBE_TIMEOUT,
+    )
+    .await
+    .context("wait for bridge subscribe ack")?;
+
+    let id = request.id.clone();
+    let waits_for_screenshot = request.action == BridgeControlAction::Screenshot;
+    let control = BridgeClientMessage::ControlRequest(request);
+    if control.is_desktop_remote_control_message() {
+        bail!("bridge control request used Desktop remote-control wire shape");
+    }
+    send_json(&mut ws, &control)
+        .await
+        .context("send bridge control request")?;
+
+    let forwarded = wait_for_server_message(
+        &mut ws,
+        |message| {
+            matches!(
+                message,
+                BridgeServerMessage::ControlForwarded {
+                    id: forwarded_id,
+                    ..
+                } if forwarded_id == &id
+            )
+        },
+        CONTROL_FORWARDED_TIMEOUT,
+    )
+    .await
+    .context("wait for bridge control forwarded")?;
+    let delivered = match forwarded {
+        BridgeServerMessage::ControlForwarded { delivered, .. } => delivered,
+        _ => 0,
+    };
+
+    let mut result = None;
+    let mut ok = None;
+    let mut screenshot = None;
+    timeout(result_timeout, async {
+        while ok.is_none() || (waits_for_screenshot && screenshot.is_none()) {
+            let Some(message) = next_server_message(&mut ws).await? else {
+                break;
+            };
+            match message {
+                BridgeServerMessage::ControlResult {
+                    id: result_id,
+                    ok: result_ok,
+                    result: value,
+                    error,
+                } if result_id == id => {
+                    if !result_ok {
+                        let message = error
+                            .as_ref()
+                            .and_then(|value| value.get("message"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("bridge control request failed");
+                        bail!("{message}");
+                    }
+                    ok = Some(true);
+                    result = value;
+                }
+                BridgeServerMessage::Screenshot {
+                    id: screenshot_id,
+                    mime,
+                    data,
+                } if screenshot_id == id => {
+                    screenshot = Some(BridgeScreenshot {
+                        mime,
+                        data_len: data.len(),
+                    });
+                }
+                _ => {}
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .context("timed out waiting for bridge control result")??;
+
+    Ok(BridgeControlOutcome {
+        delivered,
+        ok: ok.unwrap_or(false),
+        result,
+        screenshot,
+    })
+}
+
+fn default_levels() -> Vec<String> {
+    vec!["errors".to_string()]
+}
+
+fn default_capabilities() -> Vec<String> {
+    vec![
+        "console".to_string(),
+        "control".to_string(),
+        "error".to_string(),
+        "pageview".to_string(),
+        "screenshot".to_string(),
+    ]
+}
+
+fn default_filter() -> String {
+    "off".to_string()
+}
+
+fn normalize_unique(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+async fn compute_staleness(meta: &BridgeMeta, path: &Path) -> (bool, Option<i64>) {
+    if let Some(heartbeat_at) = meta.heartbeat_at {
+        let age = Utc::now().signed_duration_since(heartbeat_at);
+        let age_ms = age.num_milliseconds();
+        return (age_ms > HEARTBEAT_STALE_MS, Some(age_ms));
+    }
+
+    if let Ok(metadata) = fs::metadata(path).await {
+        if let Ok(modified) = metadata.modified() {
+            let modified: DateTime<Utc> = modified.into();
+            let age = Utc::now().signed_duration_since(modified);
+            let age_ms = age.num_milliseconds();
+            return (age_ms > HEARTBEAT_STALE_MS, Some(age_ms));
+        }
+    }
+
+    (false, None)
+}
+
+fn client_id_for(target: &BridgeTarget) -> String {
+    let workspace_name = target
+        .meta
+        .workspace_path
+        .as_deref()
+        .and_then(|path| Path::new(path).file_name())
+        .and_then(|name| name.to_str())
+        .unwrap_or("workspace");
+    format!("code-bridge-{workspace_name}")
+}
+
+async fn send_json<S>(ws: &mut S, value: &impl Serialize) -> Result<()>
+where
+    S: futures::SinkExt<Message> + Unpin,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    let text = serde_json::to_string(value).context("serialize bridge message")?;
+    ws.send(Message::Text(text.into())).await?;
+    Ok(())
+}
+
+async fn wait_for_server_message<S, F>(
+    ws: &mut S,
+    mut matches: F,
+    duration: Duration,
+) -> Result<BridgeServerMessage>
+where
+    S: futures::StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+    F: FnMut(&BridgeServerMessage) -> bool,
+{
+    timeout(duration, async {
+        while let Some(message) = next_server_message(ws).await? {
+            if matches(&message) {
+                return Ok(message);
+            }
+        }
+        bail!("bridge stream closed before expected message")
+    })
+    .await
+    .context("timed out waiting for bridge message")?
+}
+
+async fn next_server_message<S>(ws: &mut S) -> Result<Option<BridgeServerMessage>>
+where
+    S: futures::StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    while let Some(message) = ws.next().await {
+        match message? {
+            Message::Text(text) => {
+                let message = serde_json::from_str::<BridgeServerMessage>(&text)
+                    .with_context(|| format!("parse bridge message `{text}`"))?;
+                return Ok(Some(message));
+            }
+            Message::Close(_) => return Ok(None),
+            Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use chrono::Duration as ChronoDuration;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn discovery_finds_parent_metadata_and_marks_fresh() -> Result<()> {
+        let workspace = TempDir::new()?;
+        let code_dir = workspace.path().join(".code");
+        fs::create_dir(&code_dir)?;
+        fs::write(
+            code_dir.join(META_FILE),
+            serde_json::to_string(&json!({
+                "url": "ws://127.0.0.1:1",
+                "secret": "secret",
+                "workspacePath": workspace.path(),
+                "heartbeatAt": Utc::now(),
+            }))?,
+        )?;
+        let child = workspace.path().join("a").join("b");
+        fs::create_dir_all(&child)?;
+
+        let targets = discover_bridge_targets(&child).await?;
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].meta.secret, "secret");
+        assert!(!targets[0].stale);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn discovery_marks_stale_heartbeat() -> Result<()> {
+        let workspace = TempDir::new()?;
+        let code_dir = workspace.path().join(".code");
+        fs::create_dir(&code_dir)?;
+        fs::write(
+            code_dir.join(META_FILE),
+            serde_json::to_string(&json!({
+                "url": "ws://127.0.0.1:1",
+                "secret": "secret",
+                "heartbeatAt": Utc::now() - ChronoDuration::milliseconds(HEARTBEAT_STALE_MS + 1_000),
+            }))?,
+        )?;
+
+        let targets = discover_bridge_targets(workspace.path()).await?;
+
+        assert_eq!(targets.len(), 1);
+        assert!(targets[0].stale);
+        assert!(targets[0].heartbeat_age_ms.unwrap_or_default() >= HEARTBEAT_STALE_MS);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subscription_defaults_and_overrides_are_normalized() -> Result<()> {
+        let workspace = TempDir::new()?;
+
+        let defaults = load_subscription(workspace.path()).await?;
+        assert_eq!(defaults.levels, vec!["errors"]);
+        assert_eq!(
+            defaults.capabilities,
+            vec!["console", "control", "error", "pageview", "screenshot"]
+        );
+        assert_eq!(defaults.llm_filter, "off");
+
+        let code_dir = workspace.path().join(".code");
+        fs::create_dir(&code_dir)?;
+        fs::write(
+            code_dir.join(SUBSCRIPTION_FILE),
+            r#"{
+                "levels": [" Warn ", "errors", "WARN", ""],
+                "capabilities": [" Control", "console", "control"],
+                "llm_filter": " TRACE "
+            }"#,
+        )?;
+
+        let override_subscription = load_subscription(workspace.path()).await?;
+        assert_eq!(override_subscription.levels, vec!["errors", "warn"]);
+        assert_eq!(override_subscription.capabilities, vec!["console", "control"]);
+        assert_eq!(override_subscription.llm_filter, "trace");
+        Ok(())
+    }
+
+    #[test]
+    fn bridge_control_message_is_not_desktop_remote_control_shape() -> Result<()> {
+        let message = BridgeClientMessage::ControlRequest(BridgeControlRequest {
+            id: "request-1".to_string(),
+            action: BridgeControlAction::Javascript,
+            code: Some("location.href".to_string()),
+            timeout_ms: Some(1_000),
+            expect_result: Some(true),
+        });
+
+        let wire = serde_json::to_value(&message)?;
+        assert_eq!(wire.get("type").and_then(Value::as_str), Some("control_request"));
+        assert!(wire.get("method").is_none());
+        assert!(!message.is_desktop_remote_control_message());
+        Ok(())
+    }
+}

--- a/code-rs/core/src/lib.rs
+++ b/code-rs/core/src/lib.rs
@@ -10,6 +10,7 @@ mod apps;
 mod arc_monitor;
 mod client;
 mod client_common;
+pub mod code_bridge;
 mod realtime_context;
 mod realtime_conversation;
 mod realtime_prompt;

--- a/code-rs/core/tests/suite/code_bridge.rs
+++ b/code-rs/core/tests/suite/code_bridge.rs
@@ -1,0 +1,245 @@
+use std::fs;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use codex_core::code_bridge::BridgeControlAction;
+use codex_core::code_bridge::BridgeControlRequest;
+use codex_core::code_bridge::META_FILE;
+use codex_core::code_bridge::discover_bridge_targets;
+use codex_core::code_bridge::load_subscription;
+use codex_core::code_bridge::request_control;
+use futures::SinkExt;
+use futures::StreamExt;
+use serde_json::Value;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+
+#[tokio::test]
+async fn fake_bridge_round_trip_covers_subscription_and_control_result() -> Result<()> {
+    let fake = FakeBridgeServer::start(FakeBridgeControlResponse::Success).await?;
+    let workspace = TempDir::new()?;
+    let code_dir = workspace.path().join(".code");
+    fs::create_dir(&code_dir)?;
+    fs::write(
+        code_dir.join(META_FILE),
+        serde_json::to_string(&json!({
+            "url": fake.url,
+            "secret": fake.secret,
+            "workspacePath": workspace.path(),
+            "heartbeatAt": chrono::Utc::now(),
+        }))?,
+    )?;
+    fs::write(
+        code_dir.join(codex_core::code_bridge::SUBSCRIPTION_FILE),
+        r#"{
+            "levels": ["info", "errors", "INFO"],
+            "capabilities": ["control", "screenshot", "control"],
+            "llmFilter": "off"
+        }"#,
+    )?;
+
+    let mut targets = discover_bridge_targets(workspace.path()).await?;
+    assert_eq!(targets.len(), 1);
+    let target = targets.remove(0);
+    assert!(!target.stale);
+
+    let subscription = load_subscription(workspace.path()).await?;
+    let outcome = request_control(
+        &target,
+        &subscription,
+        BridgeControlRequest {
+            id: "control-1".to_string(),
+            action: BridgeControlAction::Ping,
+            code: None,
+            timeout_ms: Some(1_000),
+            expect_result: Some(true),
+        },
+        Duration::from_secs(2),
+    )
+    .await?;
+
+    let observed = fake.wait().await?;
+    assert_eq!(outcome.delivered, 1);
+    assert!(outcome.ok);
+    assert_eq!(outcome.result, Some(json!({ "pong": true })));
+
+    assert_eq!(observed.auth["type"], "auth");
+    assert_eq!(observed.auth["role"], "consumer");
+    assert_eq!(observed.auth["secret"], "bridge-secret");
+    assert_eq!(observed.subscribe["type"], "subscribe");
+    assert_eq!(observed.subscribe["levels"], json!(["errors", "info"]));
+    assert_eq!(
+        observed.subscribe["capabilities"],
+        json!(["control", "screenshot"])
+    );
+    assert_eq!(observed.subscribe["llmFilter"], "off");
+    assert!(observed.subscribe.get("llm_filter").is_none());
+    assert_eq!(observed.control["type"], "control_request");
+    assert_eq!(observed.control["id"], "control-1");
+    assert_eq!(observed.control["action"], "ping");
+    assert!(observed.control.get("method").is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn fake_bridge_failed_control_result_is_returned_as_error() -> Result<()> {
+    let fake = FakeBridgeServer::start(FakeBridgeControlResponse::Failure).await?;
+    let workspace = TempDir::new()?;
+    let code_dir = workspace.path().join(".code");
+    fs::create_dir(&code_dir)?;
+    fs::write(
+        code_dir.join(META_FILE),
+        serde_json::to_string(&json!({
+            "url": fake.url,
+            "secret": fake.secret,
+            "workspacePath": workspace.path(),
+            "heartbeatAt": chrono::Utc::now(),
+        }))?,
+    )?;
+
+    let mut targets = discover_bridge_targets(workspace.path()).await?;
+    let target = targets.remove(0);
+    let subscription = load_subscription(workspace.path()).await?;
+    let err = request_control(
+        &target,
+        &subscription,
+        BridgeControlRequest {
+            id: "control-1".to_string(),
+            action: BridgeControlAction::Ping,
+            code: None,
+            timeout_ms: Some(1_000),
+            expect_result: Some(true),
+        },
+        Duration::from_secs(2),
+    )
+    .await
+    .expect_err("failed control result should surface as an error");
+
+    let observed = fake.wait().await?;
+    assert_eq!(observed.control["type"], "control_request");
+    assert!(err.to_string().contains("bridge refused ping"));
+    Ok(())
+}
+
+struct FakeBridgeServer {
+    url: String,
+    secret: String,
+    observed_rx: oneshot::Receiver<Result<ObservedBridgeMessages>>,
+    task: JoinHandle<()>,
+}
+
+impl FakeBridgeServer {
+    async fn start(response: FakeBridgeControlResponse) -> Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("bind fake bridge server")?;
+        let url = format!("ws://{}", listener.local_addr()?);
+        let (observed_tx, observed_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let observed = accept_one(listener, response).await;
+            let _ = observed_tx.send(observed);
+        });
+
+        Ok(Self {
+            url,
+            secret: "bridge-secret".to_string(),
+            observed_rx,
+            task,
+        })
+    }
+
+    async fn wait(self) -> Result<ObservedBridgeMessages> {
+        let observed = self
+            .observed_rx
+            .await
+            .context("fake bridge server should send observed messages")??;
+        self.task.await.context("fake bridge server task should join")?;
+        Ok(observed)
+    }
+}
+
+struct ObservedBridgeMessages {
+    auth: Value,
+    subscribe: Value,
+    control: Value,
+}
+
+#[derive(Clone, Copy)]
+enum FakeBridgeControlResponse {
+    Success,
+    Failure,
+}
+
+async fn accept_one(
+    listener: TcpListener,
+    response: FakeBridgeControlResponse,
+) -> Result<ObservedBridgeMessages> {
+    let (stream, _) = listener.accept().await.context("accept fake bridge client")?;
+    let mut websocket = accept_async(stream)
+        .await
+        .context("accept fake bridge websocket")?;
+
+    let auth = read_text_json(&mut websocket).await?;
+    websocket
+        .send(Message::Text(json!({ "type": "auth_success" }).to_string().into()))
+        .await
+        .context("send auth success")?;
+
+    let subscribe = read_text_json(&mut websocket).await?;
+    websocket
+        .send(Message::Text(json!({ "type": "subscribe_ack" }).to_string().into()))
+        .await
+        .context("send subscribe ack")?;
+
+    let control = read_text_json(&mut websocket).await?;
+    let id = control
+        .get("id")
+        .and_then(Value::as_str)
+        .context("control request should include id")?;
+    websocket
+        .send(Message::Text(
+            json!({ "type": "control_forwarded", "id": id, "delivered": 1 })
+                .to_string()
+                .into(),
+        ))
+        .await
+        .context("send control forwarded")?;
+    let result = match response {
+        FakeBridgeControlResponse::Success => {
+            json!({ "type": "control_result", "id": id, "ok": true, "result": { "pong": true } })
+        }
+        FakeBridgeControlResponse::Failure => {
+            json!({ "type": "control_result", "id": id, "ok": false, "error": { "message": "bridge refused ping" } })
+        }
+    };
+    websocket
+        .send(Message::Text(result.to_string().into()))
+        .await
+        .context("send control result")?;
+
+    Ok(ObservedBridgeMessages {
+        auth,
+        subscribe,
+        control,
+    })
+}
+
+async fn read_text_json<S>(websocket: &mut S) -> Result<Value>
+where
+    S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    while let Some(message) = websocket.next().await {
+        match message? {
+            Message::Text(text) => return Ok(serde_json::from_str(&text)?),
+            Message::Close(_) => anyhow::bail!("fake bridge websocket closed early"),
+            Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+        }
+    }
+    anyhow::bail!("fake bridge websocket ended before text message")
+}

--- a/code-rs/core/tests/suite/mod.rs
+++ b/code-rs/core/tests/suite/mod.rs
@@ -38,6 +38,7 @@ mod approvals;
 mod cli_stream;
 mod client;
 mod client_websockets;
+mod code_bridge;
 mod code_mode;
 mod codex_delegate;
 mod collaboration_instructions;

--- a/docs/code-bridge-browser-parity.md
+++ b/docs/code-bridge-browser-parity.md
@@ -64,7 +64,8 @@ after local-page fixtures prove the lifecycle boundary.
 1. Add fake bridge metadata/server fixtures that prove discovery, stale heartbeat
    detection, subscription normalization, and control request/result matching,
    while first proving Code Bridge-shaped control does not enter the Codex
-   Desktop remote-control JSON-RPC path.
+   Desktop remote-control JSON-RPC path. The app-server path separation fixture
+   landed in #417; core fake bridge fixtures landed in #399 follow-up work.
 2. Port the local navigation probe to the new overlay boundary using a local HTTP
    server and no external network.
 3. Add TUI snapshot coverage only after event schema and storage are stable.


### PR DESCRIPTION
Updates #399.

## Summary
- Adds a small additive `codex_core::code_bridge` overlay for bridge metadata discovery, subscription normalization, and control request/result handling.
- Adds fake local WebSocket bridge fixtures that cover auth, subscribe, forwarded control, successful control results, and failed control results.
- Preserves the Codex/Desktop app-server `remoteControl/*` boundary: bridge control frames stay on `type=control_request` and do not use JSON-RPC `method` dispatch.
- Updates the Code Bridge/browser parity doc with the core fake fixture progress.

## Validation
- `cargo test -p codex-core code_bridge --lib -- --nocapture`
- `cargo test -p codex-core --test all code_bridge -- --nocapture`
- `git diff --check`
- `./build-fast.sh`
- Claude scoped review findings addressed: `llmFilter` wire key, non-screenshot result wait behavior, and failed control result surfacing.

## Notes
- The background auto-review ledger is failing on the unrelated oversized `spike/codex-base-port` diff scope, not this branch.
