### PR TITLE
Add fake Code Bridge local event fixtures

### DIFF
--- a/code-rs/core/src/code_bridge.rs
+++ b/code-rs/core/src/code_bridge.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use chrono::DateTime;
 use chrono::Utc;
 use serde::Deserialize;
@@ -79,10 +81,11 @@ impl BridgeSubscription {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum BridgeClientMessage {
+pub(crate) enum BridgeClientMessage {
     Auth {
         role: BridgeRole,
         secret: String,
+        #[serde(rename = "clientId")]
         client_id: String,
     },
     Subscribe {
@@ -96,6 +99,8 @@ pub enum BridgeClientMessage {
 
 impl BridgeClientMessage {
     pub fn is_desktop_remote_control_message(&self) -> bool {
+        // Structural boundary check: bridge messages should never gain the
+        // JSON-RPC `method` discriminator used by Desktop remote-control.
         serde_json::to_value(self)
             .ok()
             .and_then(|value| {
@@ -110,7 +115,7 @@ impl BridgeClientMessage {
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub enum BridgeRole {
+pub(crate) enum BridgeRole {
     Consumer,
 }
 
@@ -137,9 +142,10 @@ pub enum BridgeControlAction {
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum BridgeServerMessage {
+pub(crate) enum BridgeServerMessage {
     AuthSuccess,
     SubscribeAck,
+    Event(BridgeEvent),
     ControlForwarded {
         id: String,
         delivered: usize,
@@ -171,6 +177,38 @@ pub struct BridgeControlOutcome {
 pub struct BridgeScreenshot {
     pub mime: String,
     pub data_len: usize,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum BridgeEventData {
+    Console {
+        level: String,
+        message: String,
+    },
+    Error {
+        message: String,
+        #[serde(default)]
+        stack: Option<String>,
+    },
+    Pageview {
+        url: String,
+        #[serde(default)]
+        title: Option<String>,
+    },
+    Screenshot {
+        mime: String,
+        data_len: usize,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeEvent {
+    pub page_id: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(flatten)]
+    pub data: BridgeEventData,
 }
 
 pub async fn discover_bridge_targets(cwd: &Path) -> Result<Vec<BridgeTarget>> {
@@ -224,36 +262,7 @@ pub async fn request_control(
         .await
         .with_context(|| format!("connect to bridge {}", target.meta.url))?;
 
-    let auth = BridgeClientMessage::Auth {
-        role: BridgeRole::Consumer,
-        secret: target.meta.secret.clone(),
-        client_id: client_id_for(target),
-    };
-    send_json(&mut ws, &auth).await.context("send bridge auth")?;
-    wait_for_server_message(
-        &mut ws,
-        |message| matches!(message, BridgeServerMessage::AuthSuccess),
-        AUTH_TIMEOUT,
-    )
-    .await
-    .context("wait for bridge auth success")?;
-
-    let subscription = subscription.clone().normalized();
-    let subscribe = BridgeClientMessage::Subscribe {
-        levels: subscription.levels,
-        capabilities: subscription.capabilities,
-        llm_filter: subscription.llm_filter,
-    };
-    send_json(&mut ws, &subscribe)
-        .await
-        .context("send bridge subscribe")?;
-    wait_for_server_message(
-        &mut ws,
-        |message| matches!(message, BridgeServerMessage::SubscribeAck),
-        SUBSCRIBE_TIMEOUT,
-    )
-    .await
-    .context("wait for bridge subscribe ack")?;
+    send_auth_and_subscribe(&mut ws, target, subscription).await?;
 
     let id = request.id.clone();
     let waits_for_screenshot = request.action == BridgeControlAction::Screenshot;
@@ -318,7 +327,7 @@ pub async fn request_control(
                 } if screenshot_id == id => {
                     screenshot = Some(BridgeScreenshot {
                         mime,
-                        data_len: data.len(),
+                        data_len: decoded_data_len(&data),
                     });
                 }
                 _ => {}
@@ -335,6 +344,39 @@ pub async fn request_control(
         result,
         screenshot,
     })
+}
+
+pub async fn collect_events(
+    target: &BridgeTarget,
+    subscription: &BridgeSubscription,
+    max_events: usize,
+    event_timeout: Duration,
+) -> Result<Vec<BridgeEvent>> {
+    let (mut ws, _) = connect_async(&target.meta.url)
+        .await
+        .with_context(|| format!("connect to bridge {}", target.meta.url))?;
+
+    send_auth_and_subscribe(&mut ws, target, subscription).await?;
+
+    let mut events = Vec::new();
+    let collect_result = timeout(event_timeout, async {
+        while events.len() < max_events {
+            let Some(message) = next_server_message(&mut ws).await? else {
+                break;
+            };
+            if let BridgeServerMessage::Event(event) = message {
+                events.push(event);
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+
+    if let Ok(result) = collect_result {
+        result?;
+    }
+
+    Ok(events)
 }
 
 fn default_levels() -> Vec<String> {
@@ -363,6 +405,13 @@ fn normalize_unique(values: Vec<String>) -> Vec<String> {
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+fn decoded_data_len(data: &str) -> usize {
+    BASE64_STANDARD
+        .decode(data)
+        .map(|bytes| bytes.len())
+        .unwrap_or_else(|_| data.len())
 }
 
 async fn compute_staleness(meta: &BridgeMeta, path: &Path) -> (bool, Option<i64>) {
@@ -402,6 +451,51 @@ where
 {
     let text = serde_json::to_string(value).context("serialize bridge message")?;
     ws.send(Message::Text(text.into())).await?;
+    Ok(())
+}
+
+async fn send_auth_and_subscribe<S>(
+    ws: &mut S,
+    target: &BridgeTarget,
+    subscription: &BridgeSubscription,
+) -> Result<()>
+where
+    S: futures::SinkExt<Message>
+        + futures::StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>
+        + Unpin,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    let auth = BridgeClientMessage::Auth {
+        role: BridgeRole::Consumer,
+        secret: target.meta.secret.clone(),
+        client_id: client_id_for(target),
+    };
+    send_json(ws, &auth).await.context("send bridge auth")?;
+    wait_for_server_message(
+        ws,
+        |message| matches!(message, BridgeServerMessage::AuthSuccess),
+        AUTH_TIMEOUT,
+    )
+    .await
+    .context("wait for bridge auth success")?;
+
+    let subscription = subscription.clone().normalized();
+    let subscribe = BridgeClientMessage::Subscribe {
+        levels: subscription.levels,
+        capabilities: subscription.capabilities,
+        llm_filter: subscription.llm_filter,
+    };
+    send_json(ws, &subscribe)
+        .await
+        .context("send bridge subscribe")?;
+    wait_for_server_message(
+        ws,
+        |message| matches!(message, BridgeServerMessage::SubscribeAck),
+        SUBSCRIBE_TIMEOUT,
+    )
+    .await
+    .context("wait for bridge subscribe ack")?;
+
     Ok(())
 }
 

--- a/code-rs/core/tests/suite/code_bridge.rs
+++ b/code-rs/core/tests/suite/code_bridge.rs
@@ -5,7 +5,9 @@ use anyhow::Context;
 use anyhow::Result;
 use codex_core::code_bridge::BridgeControlAction;
 use codex_core::code_bridge::BridgeControlRequest;
+use codex_core::code_bridge::BridgeEventData;
 use codex_core::code_bridge::META_FILE;
+use codex_core::code_bridge::collect_events;
 use codex_core::code_bridge::discover_bridge_targets;
 use codex_core::code_bridge::load_subscription;
 use codex_core::code_bridge::request_control;
@@ -22,8 +24,17 @@ use tokio_tungstenite::tungstenite::Message;
 
 #[tokio::test]
 async fn fake_bridge_round_trip_covers_subscription_and_control_result() -> Result<()> {
-    let fake = FakeBridgeServer::start(FakeBridgeControlResponse::Success).await?;
+    let fake = FakeBridgeServer::start(FakeBridgeMode::Control(FakeBridgeControlResponse::Success))
+        .await?;
     let workspace = TempDir::new()?;
+    let expected_client_id = format!(
+        "code-bridge-{}",
+        workspace
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("workspace")
+    );
     let code_dir = workspace.path().join(".code");
     fs::create_dir(&code_dir)?;
     fs::write(
@@ -72,6 +83,8 @@ async fn fake_bridge_round_trip_covers_subscription_and_control_result() -> Resu
     assert_eq!(observed.auth["type"], "auth");
     assert_eq!(observed.auth["role"], "consumer");
     assert_eq!(observed.auth["secret"], "bridge-secret");
+    assert_eq!(observed.auth["clientId"], expected_client_id);
+    assert!(observed.auth.get("client_id").is_none());
     assert_eq!(observed.subscribe["type"], "subscribe");
     assert_eq!(observed.subscribe["levels"], json!(["errors", "info"]));
     assert_eq!(
@@ -89,7 +102,8 @@ async fn fake_bridge_round_trip_covers_subscription_and_control_result() -> Resu
 
 #[tokio::test]
 async fn fake_bridge_failed_control_result_is_returned_as_error() -> Result<()> {
-    let fake = FakeBridgeServer::start(FakeBridgeControlResponse::Failure).await?;
+    let fake = FakeBridgeServer::start(FakeBridgeMode::Control(FakeBridgeControlResponse::Failure))
+        .await?;
     let workspace = TempDir::new()?;
     let code_dir = workspace.path().join(".code");
     fs::create_dir(&code_dir)?;
@@ -127,6 +141,71 @@ async fn fake_bridge_failed_control_result_is_returned_as_error() -> Result<()> 
     Ok(())
 }
 
+#[tokio::test]
+async fn fake_bridge_local_page_events_cover_navigation_console_and_screenshot() -> Result<()> {
+    let local_page = LocalPageServer::start().await?;
+    let local_page_url = local_page.url.clone();
+    let fake = FakeBridgeServer::start(FakeBridgeMode::Events {
+        url: local_page_url.clone(),
+    })
+    .await?;
+    let workspace = TempDir::new()?;
+    let code_dir = workspace.path().join(".code");
+    fs::create_dir(&code_dir)?;
+    fs::write(
+        code_dir.join(META_FILE),
+        serde_json::to_string(&json!({
+            "url": fake.url,
+            "secret": fake.secret,
+            "workspacePath": workspace.path(),
+            "heartbeatAt": chrono::Utc::now(),
+        }))?,
+    )?;
+
+    let mut targets = discover_bridge_targets(workspace.path()).await?;
+    let target = targets.remove(0);
+    let subscription = load_subscription(workspace.path()).await?;
+    let body = reqwest::get(&local_page.url).await?.text().await?;
+    assert!(body.contains("Local Navigation Fixture"));
+
+    let events = collect_events(&target, &subscription, 3, Duration::from_secs(2)).await?;
+    local_page.wait().await?;
+
+    let observed = fake.wait().await?;
+    assert_eq!(observed.subscribe["type"], "subscribe");
+    assert!(observed.control.is_null());
+    assert_eq!(events.len(), 3);
+
+    assert_eq!(events[0].page_id, "local-page");
+    match &events[0].data {
+        BridgeEventData::Pageview { url, title } => {
+            assert_eq!(url, &local_page_url);
+            assert_eq!(title.as_deref(), Some("Local Navigation Fixture"));
+        }
+        other => panic!("expected pageview event, got {other:?}"),
+    }
+
+    match &events[1].data {
+        BridgeEventData::Console { level, message } => {
+            assert_eq!(events[1].page_id, "local-page");
+            assert_eq!(level, "info");
+            assert_eq!(message, "local navigation ready");
+        }
+        other => panic!("expected console event, got {other:?}"),
+    }
+
+    match &events[2].data {
+        BridgeEventData::Screenshot { mime, data_len } => {
+            assert_eq!(events[2].page_id, "local-page");
+            assert_eq!(mime, "image/png");
+            assert_eq!(*data_len, 68);
+        }
+        other => panic!("expected screenshot event, got {other:?}"),
+    }
+
+    Ok(())
+}
+
 struct FakeBridgeServer {
     url: String,
     secret: String,
@@ -135,14 +214,14 @@ struct FakeBridgeServer {
 }
 
 impl FakeBridgeServer {
-    async fn start(response: FakeBridgeControlResponse) -> Result<Self> {
+    async fn start(mode: FakeBridgeMode) -> Result<Self> {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .context("bind fake bridge server")?;
         let url = format!("ws://{}", listener.local_addr()?);
         let (observed_tx, observed_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
-            let observed = accept_one(listener, response).await;
+            let observed = accept_one(listener, mode).await;
             let _ = observed_tx.send(observed);
         });
 
@@ -170,6 +249,12 @@ struct ObservedBridgeMessages {
     control: Value,
 }
 
+#[derive(Clone)]
+enum FakeBridgeMode {
+    Control(FakeBridgeControlResponse),
+    Events { url: String },
+}
+
 #[derive(Clone, Copy)]
 enum FakeBridgeControlResponse {
     Success,
@@ -178,7 +263,7 @@ enum FakeBridgeControlResponse {
 
 async fn accept_one(
     listener: TcpListener,
-    response: FakeBridgeControlResponse,
+    mode: FakeBridgeMode,
 ) -> Result<ObservedBridgeMessages> {
     let (stream, _) = listener.accept().await.context("accept fake bridge client")?;
     let mut websocket = accept_async(stream)
@@ -196,6 +281,18 @@ async fn accept_one(
         .send(Message::Text(json!({ "type": "subscribe_ack" }).to_string().into()))
         .await
         .context("send subscribe ack")?;
+
+    let FakeBridgeMode::Control(response) = mode else {
+        let FakeBridgeMode::Events { url } = mode else {
+            unreachable!("control mode handled above")
+        };
+        send_local_page_events(&mut websocket, &url).await?;
+        return Ok(ObservedBridgeMessages {
+            auth,
+            subscribe,
+            control: Value::Null,
+        });
+    };
 
     let control = read_text_json(&mut websocket).await?;
     let id = control
@@ -228,6 +325,80 @@ async fn accept_one(
         subscribe,
         control,
     })
+}
+
+async fn send_local_page_events<S>(websocket: &mut S, url: &str) -> Result<()>
+where
+    S: SinkExt<Message> + Unpin,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    let timestamp = "2026-06-06T12:00:00Z";
+    let events = [
+        json!({
+            "type": "event",
+            "kind": "pageview",
+            "pageId": "local-page",
+            "timestamp": timestamp,
+            "url": url,
+            "title": "Local Navigation Fixture"
+        }),
+        json!({
+            "type": "event",
+            "kind": "console",
+            "pageId": "local-page",
+            "timestamp": timestamp,
+            "level": "info",
+            "message": "local navigation ready"
+        }),
+        json!({
+            "type": "event",
+            "kind": "screenshot",
+            "pageId": "local-page",
+            "timestamp": timestamp,
+            "mime": "image/png",
+            "dataLen": 68
+        }),
+    ];
+    for event in events {
+        websocket
+            .send(Message::Text(event.to_string().into()))
+            .await
+            .context("send local page bridge event")?;
+    }
+    Ok(())
+}
+
+struct LocalPageServer {
+    url: String,
+    task: JoinHandle<Result<()>>,
+}
+
+impl LocalPageServer {
+    async fn start() -> Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("bind local page server")?;
+        let url = format!("http://{}/local-navigation", listener.local_addr()?);
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.context("accept local page request")?;
+            let body = "<html><head><title>Local Navigation Fixture</title></head><body>Local Navigation Fixture</body></html>";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes())
+                .await
+                .context("write local page response")?;
+            Ok(())
+        });
+
+        Ok(Self { url, task })
+    }
+
+    async fn wait(self) -> Result<()> {
+        self.task.await.context("local page server task should join")?
+    }
 }
 
 async fn read_text_json<S>(websocket: &mut S) -> Result<Value>

--- a/docs/code-bridge-browser-parity.md
+++ b/docs/code-bridge-browser-parity.md
@@ -65,9 +65,11 @@ after local-page fixtures prove the lifecycle boundary.
    detection, subscription normalization, and control request/result matching,
    while first proving Code Bridge-shaped control does not enter the Codex
    Desktop remote-control JSON-RPC path. The app-server path separation fixture
-   landed in #417; core fake bridge fixtures landed in #399 follow-up work.
+   landed in #417; core fake bridge fixtures landed in #418.
 2. Port the local navigation probe to the new overlay boundary using a local HTTP
-   server and no external network.
+   server and no external network. First land bridge event fixtures for local
+   `pageview`, `console`, and `screenshot` payloads before reintroducing a
+   browser runtime.
 3. Add TUI snapshot coverage only after event schema and storage are stable.
 4. Wire implementation behind the additive Every Code bridge surface.
 


### PR DESCRIPTION
Updates #399.

## Summary
- Adds typed passive Code Bridge event payloads for `pageview`, `console`, `error`, and `screenshot` in the additive `codex_core::code_bridge` overlay.
- Adds `collect_events` to authenticate, subscribe, and collect bridge events without using the Desktop/app-server `remoteControl/*` path.
- Extends the fake WebSocket bridge fixture with a real loopback HTTP page and local `pageview`/`console`/`screenshot` event payload coverage.
- Narrows internal bridge wire enums, keeps auth wire fields camelCase (`clientId`), and preserves partial event batches when collection times out.
- Updates the #399 boundary doc to record #418 and the local event fixture step before any browser runtime port.

## Validation
- `cargo test -p codex-core code_bridge --lib -- --nocapture`
- `cargo test -p codex-core --test all code_bridge -- --nocapture`
- `git diff --check`
- `./build-fast.sh`
- Claude scoped review: no blockers; low hardening suggestions addressed.
- Gemini/Antigravity scoped review: medium timeout-semantic finding and low wire/API findings addressed.

## Notes
- This PR intentionally does not port the old browser crate or TUI cells. It adds deterministic local event fixtures first, preserving the Codex-aligned boundary for later implementation work.
- The background auto-review ledger is still failing on the unrelated oversized `spike/codex-base-port` diff scope, not this branch.
