### PR TITLE
Render Code Bridge events for models

### DIFF
--- a/code-rs/core/src/code_bridge.rs
+++ b/code-rs/core/src/code_bridge.rs
@@ -177,9 +177,10 @@ pub struct BridgeControlOutcome {
 pub struct BridgeScreenshot {
     pub mime: String,
     pub data_len: usize,
+    pub data: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
 pub enum BridgeEventData {
     Console {
@@ -202,7 +203,7 @@ pub enum BridgeEventData {
     },
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct BridgeEvent {
     pub page_id: String,
@@ -325,9 +326,11 @@ pub async fn request_control(
                     mime,
                     data,
                 } if screenshot_id == id => {
+                    let data_len = decoded_data_len(&data);
                     screenshot = Some(BridgeScreenshot {
                         mime,
-                        data_len: decoded_data_len(&data),
+                        data_len,
+                        data: Some(data),
                     });
                 }
                 _ => {}
@@ -379,6 +382,60 @@ pub async fn collect_events(
     Ok(events)
 }
 
+pub fn format_events_transcript(events: &[BridgeEvent]) -> String {
+    events
+        .iter()
+        .map(format_event_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_event_line(event: &BridgeEvent) -> String {
+    let timestamp = event.timestamp.to_rfc3339();
+    match &event.data {
+        BridgeEventData::Console { level, message } => format!(
+            "[{timestamp}] console page={} level={} message={}",
+            quote_for_transcript(&event.page_id),
+            level,
+            quote_for_transcript(message)
+        ),
+        BridgeEventData::Error { message, stack } => {
+            let mut line = format!(
+                "[{timestamp}] error page={} message={}",
+                quote_for_transcript(&event.page_id),
+                quote_for_transcript(message)
+            );
+            if let Some(stack) = stack.as_ref().filter(|stack| !stack.trim().is_empty()) {
+                line.push_str(" stack=");
+                line.push_str(&quote_for_transcript(stack));
+            }
+            line
+        }
+        BridgeEventData::Pageview { url, title } => {
+            let mut line = format!(
+                "[{timestamp}] pageview page={} url={}",
+                quote_for_transcript(&event.page_id),
+                quote_for_transcript(url)
+            );
+            if let Some(title) = title.as_ref().filter(|title| !title.trim().is_empty()) {
+                line.push_str(" title=");
+                line.push_str(&quote_for_transcript(title));
+            }
+            line
+        }
+        BridgeEventData::Screenshot { mime, data_len } => format!(
+            "[{timestamp}] screenshot page={} mime={} bytes={}",
+            quote_for_transcript(&event.page_id),
+            mime,
+            data_len
+        ),
+    }
+}
+
+fn quote_for_transcript(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
 fn default_levels() -> Vec<String> {
     vec!["errors".to_string()]
 }
@@ -411,7 +468,7 @@ fn decoded_data_len(data: &str) -> usize {
     BASE64_STANDARD
         .decode(data)
         .map(|bytes| bytes.len())
-        .unwrap_or_else(|_| data.len())
+        .unwrap_or(0)
 }
 
 async fn compute_staleness(meta: &BridgeMeta, path: &Path) -> (bool, Option<i64>) {
@@ -640,5 +697,59 @@ mod tests {
         assert!(wire.get("method").is_none());
         assert!(!message.is_desktop_remote_control_message());
         Ok(())
+    }
+
+    #[test]
+    fn format_events_transcript_renders_all_event_kinds() -> Result<()> {
+        let timestamp = DateTime::parse_from_rfc3339("2026-06-06T12:00:00Z")?.with_timezone(&Utc);
+        let events = vec![
+            BridgeEvent {
+                page_id: "page-1".to_string(),
+                timestamp,
+                data: BridgeEventData::Pageview {
+                    url: "https://example.test/app".to_string(),
+                    title: Some("Example App".to_string()),
+                },
+            },
+            BridgeEvent {
+                page_id: "page-1".to_string(),
+                timestamp,
+                data: BridgeEventData::Console {
+                    level: "info".to_string(),
+                    message: "ready".to_string(),
+                },
+            },
+            BridgeEvent {
+                page_id: "page-1".to_string(),
+                timestamp,
+                data: BridgeEventData::Error {
+                    message: "TypeError: boom".to_string(),
+                    stack: Some("at app.js:1".to_string()),
+                },
+            },
+            BridgeEvent {
+                page_id: "page-1".to_string(),
+                timestamp,
+                data: BridgeEventData::Screenshot {
+                    mime: "image/png".to_string(),
+                    data_len: 68,
+                },
+            },
+        ];
+
+        let transcript = format_events_transcript(&events);
+
+        assert!(transcript.contains("pageview page=\"page-1\""));
+        assert!(transcript.contains("url=\"https://example.test/app\""));
+        assert!(transcript.contains("console page=\"page-1\" level=info message=\"ready\""));
+        assert!(transcript.contains("error page=\"page-1\" message=\"TypeError: boom\""));
+        assert!(transcript.contains("stack=\"at app.js:1\""));
+        assert!(transcript.contains("screenshot page=\"page-1\" mime=image/png bytes=68"));
+        Ok(())
+    }
+
+    #[test]
+    fn format_events_transcript_empty_is_empty() {
+        assert_eq!(format_events_transcript(&[]), "");
     }
 }

--- a/code-rs/core/src/tools/handlers/code_bridge.rs
+++ b/code-rs/core/src/tools/handlers/code_bridge.rs
@@ -4,7 +4,9 @@ use crate::code_bridge::BridgeControlAction;
 use crate::code_bridge::BridgeControlOutcome;
 use crate::code_bridge::BridgeControlRequest;
 use crate::code_bridge::SUBSCRIPTION_FILE;
+use crate::code_bridge::collect_events;
 use crate::code_bridge::discover_bridge_targets;
+use crate::code_bridge::format_events_transcript;
 use crate::code_bridge::load_subscription;
 use crate::code_bridge::request_control;
 use crate::function_tool::FunctionCallError;
@@ -17,6 +19,9 @@ use crate::tools::handlers::parse_arguments;
 use crate::tools::registry::ToolHandler;
 use crate::tools::registry::ToolKind;
 use chrono::Utc;
+use codex_protocol::models::DEFAULT_IMAGE_DETAIL;
+use codex_protocol::models::FunctionCallOutputContentItem;
+use codex_protocol::openai_models::InputModality;
 use codex_tools::ToolName;
 use codex_tools::ToolSpec;
 use serde::Deserialize;
@@ -26,6 +31,10 @@ use serde_json::json;
 use tokio::fs;
 
 const DEFAULT_CONTROL_TIMEOUT_MS: u64 = 5_000;
+const CONTROL_RESULT_TIMEOUT_BUFFER_MS: u64 = 1_000;
+const DEFAULT_COLLECT_TIMEOUT_MS: u64 = 2_000;
+const DEFAULT_MAX_EVENTS: usize = 10;
+const MAX_EVENTS_LIMIT: usize = 100;
 
 pub struct CodeBridgeHandler;
 
@@ -33,6 +42,7 @@ pub struct CodeBridgeHandler;
 #[serde(rename_all = "snake_case")]
 enum CodeBridgeAction {
     Subscribe,
+    Collect,
     Screenshot,
     Javascript,
 }
@@ -46,6 +56,8 @@ struct CodeBridgeArgs {
     code: Option<String>,
     #[serde(default)]
     timeout_ms: Option<u64>,
+    #[serde(default)]
+    max_events: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -61,6 +73,8 @@ struct CodeBridgeToolOutput {
 struct CodeBridgeScreenshotOutput {
     mime: String,
     data_len: usize,
+    #[serde(skip)]
+    data: Option<String>,
 }
 
 impl ToolHandler for CodeBridgeHandler {
@@ -90,14 +104,19 @@ impl ToolHandler for CodeBridgeHandler {
         };
         let args: CodeBridgeArgs = parse_arguments(&arguments)?;
 
+        let supports_image = turn.model_info.input_modalities.contains(&InputModality::Image);
         let output = match args.action {
             CodeBridgeAction::Subscribe => subscribe(&turn.cwd, args.level).await?,
+            CodeBridgeAction::Collect => {
+                collect(&turn.cwd, args.max_events, args.timeout_ms).await?
+            }
             CodeBridgeAction::Screenshot => {
                 control(
                     &turn.cwd,
                     BridgeControlAction::Screenshot,
                     None,
                     args.timeout_ms,
+                    supports_image,
                 )
                 .await?
             }
@@ -112,15 +131,40 @@ impl ToolHandler for CodeBridgeHandler {
                     BridgeControlAction::Javascript,
                     Some(code),
                     args.timeout_ms,
+                    supports_image,
                 )
                 .await?
             }
         };
 
-        let text = serde_json::to_string(&output).map_err(|err| {
+        Ok(output.into_function_output()?)
+    }
+}
+
+impl CodeBridgeToolOutput {
+    fn into_function_output(self) -> Result<FunctionToolOutput, FunctionCallError> {
+        let success = Some(self.ok);
+        let screenshot_data_url = self
+            .screenshot
+            .as_ref()
+            .and_then(|screenshot| screenshot.data_url());
+        let text = serde_json::to_string(&self).map_err(|err| {
             FunctionCallError::Fatal(format!("failed to serialize code_bridge output: {err}"))
         })?;
-        Ok(FunctionToolOutput::from_text(text, Some(output.ok)))
+        if let Some(image_url) = screenshot_data_url {
+            Ok(FunctionToolOutput::from_content(
+                vec![
+                    FunctionCallOutputContentItem::InputText { text },
+                    FunctionCallOutputContentItem::InputImage {
+                        image_url,
+                        detail: Some(DEFAULT_IMAGE_DETAIL),
+                    },
+                ],
+                success,
+            ))
+        } else {
+            Ok(FunctionToolOutput::from_text(text, success))
+        }
     }
 }
 
@@ -176,24 +220,48 @@ async fn subscribe(
     })
 }
 
+async fn collect(
+    cwd: &std::path::Path,
+    max_events: Option<usize>,
+    timeout_ms: Option<u64>,
+) -> Result<CodeBridgeToolOutput, FunctionCallError> {
+    let (target, workspace) = fresh_target_and_workspace(cwd).await?;
+    let subscription = load_subscription(&workspace).await.map_err(respond_error)?;
+    let max_events = max_events.unwrap_or(DEFAULT_MAX_EVENTS).clamp(1, MAX_EVENTS_LIMIT);
+    let timeout_ms = timeout_ms
+        .unwrap_or(DEFAULT_COLLECT_TIMEOUT_MS)
+        .clamp(1, 30_000);
+    let events = collect_events(
+        &target,
+        &subscription,
+        max_events,
+        Duration::from_millis(timeout_ms),
+    )
+    .await
+    .map_err(respond_error)?;
+    let transcript = format_events_transcript(&events);
+    let event_count = events.len();
+
+    Ok(CodeBridgeToolOutput {
+        ok: true,
+        message: format!("collected {event_count} Code Bridge event(s)"),
+        delivered: None,
+        result: Some(json!({
+            "count": event_count,
+            "transcript": transcript,
+        })),
+        screenshot: None,
+    })
+}
+
 async fn control(
     cwd: &std::path::Path,
     action: BridgeControlAction,
     code: Option<String>,
     timeout_ms: Option<u64>,
+    supports_image: bool,
 ) -> Result<CodeBridgeToolOutput, FunctionCallError> {
-    let targets = discover_bridge_targets(cwd).await.map_err(respond_error)?;
-    let Some(target) = targets.iter().find(|target| !target.stale) else {
-        return Err(FunctionCallError::RespondToModel(
-            "no fresh Code Bridge metadata found under this workspace".to_string(),
-        ));
-    };
-    let workspace = target_workspace(target).ok_or_else(|| {
-        FunctionCallError::RespondToModel(format!(
-            "invalid Code Bridge metadata path {}",
-            target.meta_path.display()
-        ))
-    })?;
+    let (target, workspace) = fresh_target_and_workspace(cwd).await?;
     let subscription = load_subscription(&workspace).await.map_err(respond_error)?;
     let timeout_ms = timeout_ms.unwrap_or(DEFAULT_CONTROL_TIMEOUT_MS).clamp(1, 30_000);
     let request = BridgeControlRequest {
@@ -204,20 +272,21 @@ async fn control(
         expect_result: Some(true),
     };
     let outcome = request_control(
-        target,
+        &target,
         &subscription,
         request,
-        Duration::from_millis(timeout_ms),
+        Duration::from_millis(timeout_ms.saturating_add(CONTROL_RESULT_TIMEOUT_BUFFER_MS)),
     )
     .await
     .map_err(respond_error)?;
 
-    Ok(output_from_control(action, outcome))
+    Ok(output_from_control(action, outcome, supports_image))
 }
 
 fn output_from_control(
     action: BridgeControlAction,
     outcome: BridgeControlOutcome,
+    supports_image: bool,
 ) -> CodeBridgeToolOutput {
     CodeBridgeToolOutput {
         ok: outcome.ok,
@@ -233,7 +302,16 @@ fn output_from_control(
             .map(|screenshot| CodeBridgeScreenshotOutput {
                 mime: screenshot.mime,
                 data_len: screenshot.data_len,
+                data: screenshot.data.filter(|_| supports_image),
             }),
+    }
+}
+
+impl CodeBridgeScreenshotOutput {
+    fn data_url(&self) -> Option<String> {
+        self.data
+            .as_ref()
+            .map(|data| format!("data:{};base64,{}", self.mime, data))
     }
 }
 
@@ -248,6 +326,24 @@ async fn bridge_workspace(cwd: &std::path::Path) -> anyhow::Result<std::path::Pa
         .find(|target| !target.stale)
         .and_then(target_workspace)
         .unwrap_or_else(|| cwd.to_path_buf()))
+}
+
+async fn fresh_target_and_workspace(
+    cwd: &std::path::Path,
+) -> Result<(crate::code_bridge::BridgeTarget, std::path::PathBuf), FunctionCallError> {
+    let targets = discover_bridge_targets(cwd).await.map_err(respond_error)?;
+    let Some(target) = targets.into_iter().find(|target| !target.stale) else {
+        return Err(FunctionCallError::RespondToModel(
+            "no fresh Code Bridge metadata found under this workspace".to_string(),
+        ));
+    };
+    let workspace = target_workspace(&target).ok_or_else(|| {
+        FunctionCallError::RespondToModel(format!(
+            "invalid Code Bridge metadata path {}",
+            target.meta_path.display()
+        ))
+    })?;
+    Ok((target, workspace))
 }
 
 fn target_workspace(target: &crate::code_bridge::BridgeTarget) -> Option<std::path::PathBuf> {
@@ -265,6 +361,7 @@ mod tests {
     use crate::code_bridge::META_FILE;
     use anyhow::Context;
     use anyhow::Result;
+    use codex_protocol::models::FunctionCallOutputContentItem;
     use futures::SinkExt;
     use futures::StreamExt;
     use serde_json::json;
@@ -337,6 +434,7 @@ mod tests {
             BridgeControlAction::Javascript,
             Some("window.location.href".to_string()),
             Some(2_000),
+            false,
         )
         .await?;
         let observed = fake.wait().await?;
@@ -364,6 +462,7 @@ mod tests {
             BridgeControlAction::Screenshot,
             None,
             Some(2_000),
+            false,
         )
         .await?;
         let observed = fake.wait().await?;
@@ -375,6 +474,56 @@ mod tests {
         let screenshot = output.screenshot.context("screenshot summary")?;
         assert_eq!(screenshot.mime, "image/png");
         assert_eq!(screenshot.data_len, 4);
+        assert!(screenshot.data.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn screenshot_control_embeds_image_when_supported() -> Result<()> {
+        let fake = FakeBridgeServer::start(FakeBridgeResponse::Screenshot).await?;
+        let workspace = workspace_with_bridge_meta(&fake)?;
+
+        let output = control(
+            workspace.path(),
+            BridgeControlAction::Screenshot,
+            None,
+            Some(2_000),
+            true,
+        )
+        .await?
+        .into_function_output()?;
+        let observed = fake.wait().await?;
+
+        assert_eq!(observed.control["action"], "screenshot");
+        assert_eq!(output.success, Some(true));
+        assert!(matches!(
+            output.body.as_slice(),
+            [
+                FunctionCallOutputContentItem::InputText { .. },
+                FunctionCallOutputContentItem::InputImage { image_url, .. }
+            ] if image_url == "data:image/png;base64,AQIDBA=="
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn collect_returns_event_transcript() -> Result<()> {
+        let fake = FakeBridgeServer::start(FakeBridgeResponse::Events).await?;
+        let workspace = workspace_with_bridge_meta(&fake)?;
+
+        let output = collect(workspace.path(), Some(2), Some(2_000)).await?;
+        let observed = fake.wait().await?;
+
+        assert!(observed.control.is_null());
+        assert!(output.ok);
+        let result = output.result.context("collect result")?;
+        assert_eq!(result["count"], 2);
+        let transcript = result["transcript"]
+            .as_str()
+            .context("event transcript")?;
+        assert!(transcript.contains("pageview page=\"local-page\""));
+        assert!(transcript.contains("console page=\"local-page\" level=info"));
+        assert!(transcript.contains("local navigation ready"));
         Ok(())
     }
 
@@ -393,7 +542,15 @@ mod tests {
             .context("action schema")?;
         assert_eq!(
             action.enum_values.as_deref(),
-            Some([json!("subscribe"), json!("screenshot"), json!("javascript")].as_slice())
+            Some(
+                [
+                    json!("subscribe"),
+                    json!("collect"),
+                    json!("screenshot"),
+                    json!("javascript"),
+                ]
+                .as_slice()
+            )
         );
         Ok::<(), anyhow::Error>(())
     }
@@ -463,6 +620,7 @@ mod tests {
     enum FakeBridgeResponse {
         Javascript,
         Screenshot,
+        Events,
     }
 
     async fn accept_one(
@@ -485,6 +643,13 @@ mod tests {
             .send(Message::Text(json!({ "type": "subscribe_ack" }).to_string().into()))
             .await
             .context("send subscribe ack")?;
+
+        if matches!(response, FakeBridgeResponse::Events) {
+            send_local_page_events(&mut websocket).await?;
+            return Ok(ObservedBridgeMessages {
+                control: Value::Null,
+            });
+        }
 
         let control = read_text_json(&mut websocket).await?;
         let id = control
@@ -539,9 +704,43 @@ mod tests {
                     .await
                     .context("send screenshot payload")?;
             }
+            FakeBridgeResponse::Events => unreachable!("events mode handled before control read"),
         }
 
         Ok(ObservedBridgeMessages { control })
+    }
+
+    async fn send_local_page_events<S>(websocket: &mut S) -> Result<()>
+    where
+        S: SinkExt<Message> + Unpin,
+        S::Error: std::error::Error + Send + Sync + 'static,
+    {
+        let timestamp = "2026-06-06T12:00:00Z";
+        let events = [
+            json!({
+                "type": "event",
+                "kind": "pageview",
+                "pageId": "local-page",
+                "timestamp": timestamp,
+                "url": "http://127.0.0.1/local-navigation",
+                "title": "Local Navigation Fixture"
+            }),
+            json!({
+                "type": "event",
+                "kind": "console",
+                "pageId": "local-page",
+                "timestamp": timestamp,
+                "level": "info",
+                "message": "local navigation ready"
+            }),
+        ];
+        for event in events {
+            websocket
+                .send(Message::Text(event.to_string().into()))
+                .await
+                .context("send local page bridge event")?;
+        }
+        Ok(())
     }
 
     async fn read_text_json<S>(websocket: &mut S) -> Result<Value>

--- a/code-rs/core/src/tools/handlers/code_bridge_spec.rs
+++ b/code-rs/core/src/tools/handlers/code_bridge_spec.rs
@@ -12,8 +12,13 @@ pub fn create_code_bridge_tool() -> ToolSpec {
         (
             "action".to_string(),
             JsonSchema::string_enum(
-                vec![json!("subscribe"), json!("screenshot"), json!("javascript")],
-                Some("Required: subscribe, screenshot, or javascript.".to_string()),
+                vec![
+                    json!("subscribe"),
+                    json!("collect"),
+                    json!("screenshot"),
+                    json!("javascript"),
+                ],
+                Some("Required: subscribe, collect, screenshot, or javascript.".to_string()),
             ),
         ),
         (
@@ -33,14 +38,21 @@ pub fn create_code_bridge_tool() -> ToolSpec {
         (
             "timeout_ms".to_string(),
             JsonSchema::integer(Some(
-                "Optional control-result timeout in milliseconds.".to_string(),
+                "Optional timeout in milliseconds for control results or event collection."
+                    .to_string(),
+            )),
+        ),
+        (
+            "max_events".to_string(),
+            JsonSchema::integer(Some(
+                "For action=collect: maximum number of bridge events to collect.".to_string(),
             )),
         ),
     ]);
 
     ToolSpec::Function(ResponsesApiTool {
         name: CODE_BRIDGE_TOOL_NAME.to_string(),
-        description: "Code Bridge local app telemetry/control. Subscribe to events, request a screenshot, or run JavaScript on a connected bridge client.".to_string(),
+        description: "Code Bridge local app telemetry/control. Subscribe to events, collect recent bridge events, request a screenshot, or run JavaScript on a connected bridge client.".to_string(),
         strict: false,
         defer_loading: None,
         parameters: JsonSchema::object(


### PR DESCRIPTION
Updates #399 and #404.

## Summary
- Add a `collect` action to the existing experimental `code_bridge` function tool.
- Render collected Code Bridge pageview/console/error/screenshot events into a compact transcript returned in `result.transcript`.
- Preserve direct screenshot base64 long enough to attach an `InputImage` content item when the active model supports images, without duplicating base64 in JSON text.
- Keep the implementation on the current Codex-style function tool/result path; no new app-server/browser UI path or protocol surface.

## Review Notes
- Claude planning/review used for event transcript and multimodal output shape.
- Gemini/Antigravity planning/review used for Codex-alignment and diff-minimization checks.
- Accepted review fixes for leaner transcript output, quoted page ids, timeout wording/buffer, and invalid base64 length reporting.

## Validation
- `cargo test -p codex-core code_bridge --lib -- --nocapture`
- `cargo test -p codex-core --test all code_bridge -- --nocapture`
- `git diff --check`
- `./build-fast.sh`
