### PR TITLE
Render dynamic tool calls in TUI history

### DIFF
--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -6134,6 +6134,26 @@ impl ChatWidget {
             } => {
                 self.on_image_generation_end(id, revised_prompt, saved_path);
             }
+            ThreadItem::DynamicToolCall {
+                namespace,
+                tool,
+                arguments,
+                status,
+                content_items,
+                success,
+                ..
+            } => {
+                self.flush_answer_stream_with_separator();
+                self.add_to_history(history_cell::new_dynamic_tool_call(
+                    namespace,
+                    tool,
+                    arguments,
+                    status,
+                    content_items,
+                    success,
+                ));
+                self.request_redraw();
+            }
             ThreadItem::EnteredReviewMode { review, .. } => {
                 if from_replay {
                     self.enter_review_mode_with_hint(review, /*from_replay*/ true);
@@ -6167,7 +6187,6 @@ impl ChatWidget {
                 reasoning_effort,
                 agents_states,
             }),
-            ThreadItem::DynamicToolCall { .. } => {}
         }
 
         if matches!(replay_kind, Some(ReplayKind::ThreadSnapshot)) && turn_id.is_empty() {

--- a/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_collect_history_snapshot.snap
+++ b/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_collect_history_snapshot.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: combined
+---
+• Called code_bridge({"action":"collect"})
+  └ {"ok": true, "message": "collected 3 Code Bridge event(s)", "result":
+        {"count": 3, "transcript": "[info] App mounted\n[warn] Slow render
+        120ms\n[error] TypeError: value is null"}}

--- a/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_in_progress_history_snapshot.snap
+++ b/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_in_progress_history_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: combined
+---
+• Calling code_bridge({"action":"collect"})

--- a/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_namespace_history_snapshot.snap
+++ b/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_namespace_history_snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: combined
+---
+• Called plugin.status({"verbose":true})
+  └ ready

--- a/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_screenshot_history_snapshot.snap
+++ b/code-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__dynamic_tool_call_screenshot_history_snapshot.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: combined
+---
+• Called code_bridge({"action":"screenshot"})
+  └ {"ok": true, "message": "screenshot captured", "screenshot": {"mime":
+        "image/png", "data_len": 12345}}
+    <image content>

--- a/code-rs/tui/src/chatwidget/tests.rs
+++ b/code-rs/tui/src/chatwidget/tests.rs
@@ -51,6 +51,8 @@ pub(super) use codex_app_server_protocol::CommandExecutionSource as AppServerCom
 pub(super) use codex_app_server_protocol::CommandExecutionStatus as AppServerCommandExecutionStatus;
 pub(super) use codex_app_server_protocol::ConfigWarningNotification;
 pub(super) use codex_app_server_protocol::CreditsSnapshot;
+pub(super) use codex_app_server_protocol::DynamicToolCallOutputContentItem as AppServerDynamicToolCallOutputContentItem;
+pub(super) use codex_app_server_protocol::DynamicToolCallStatus as AppServerDynamicToolCallStatus;
 pub(super) use codex_app_server_protocol::ErrorNotification;
 pub(super) use codex_app_server_protocol::ExecPolicyAmendment;
 pub(super) use codex_app_server_protocol::FileUpdateChange;

--- a/code-rs/tui/src/chatwidget/tests/exec_flow.rs
+++ b/code-rs/tui/src/chatwidget/tests/exec_flow.rs
@@ -863,6 +863,117 @@ async fn image_generation_call_adds_history_cell() {
 }
 
 #[tokio::test]
+async fn dynamic_tool_call_collect_adds_history_cell() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+
+    handle_dynamic_tool_call(
+        &mut chat,
+        "call-code-bridge-collect",
+        None,
+        "code_bridge",
+        json!({"action":"collect"}),
+        vec![AppServerDynamicToolCallOutputContentItem::InputText {
+            text: json!({
+                "ok": true,
+                "message": "collected 3 Code Bridge event(s)",
+                "result": {
+                    "count": 3,
+                    "transcript": "[info] App mounted\n[warn] Slow render 120ms\n[error] TypeError: value is null"
+                }
+            })
+            .to_string(),
+        }],
+        true,
+    );
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected a single history cell");
+    let combined = lines_to_single_string(&cells[0]);
+    assert_chatwidget_snapshot!("dynamic_tool_call_collect_history_snapshot", combined);
+}
+
+#[tokio::test]
+async fn dynamic_tool_call_screenshot_adds_history_cell_with_image_marker() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+
+    handle_dynamic_tool_call(
+        &mut chat,
+        "call-code-bridge-screenshot",
+        None,
+        "code_bridge",
+        json!({"action":"screenshot"}),
+        vec![
+            AppServerDynamicToolCallOutputContentItem::InputText {
+                text: json!({
+                    "ok": true,
+                    "message": "screenshot captured",
+                    "screenshot": {
+                        "mime": "image/png",
+                        "data_len": 12345
+                    }
+                })
+                .to_string(),
+            },
+            AppServerDynamicToolCallOutputContentItem::InputImage {
+                image_url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
+            },
+        ],
+        true,
+    );
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected a single history cell");
+    let combined = lines_to_single_string(&cells[0]);
+    assert_chatwidget_snapshot!(
+        "dynamic_tool_call_screenshot_history_snapshot",
+        combined
+    );
+}
+
+#[tokio::test]
+async fn dynamic_tool_call_namespace_adds_history_cell() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+
+    handle_dynamic_tool_call(
+        &mut chat,
+        "call-plugin-status",
+        Some("plugin".to_string()),
+        "status",
+        json!({"verbose":true}),
+        vec![AppServerDynamicToolCallOutputContentItem::InputText {
+            text: "ready".to_string(),
+        }],
+        true,
+    );
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected a single history cell");
+    let combined = lines_to_single_string(&cells[0]);
+    assert_chatwidget_snapshot!("dynamic_tool_call_namespace_history_snapshot", combined);
+}
+
+#[tokio::test]
+async fn dynamic_tool_call_in_progress_adds_calling_history_cell() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+
+    handle_dynamic_tool_call_with_status(
+        &mut chat,
+        "call-code-bridge-running",
+        None,
+        "code_bridge",
+        json!({"action":"collect"}),
+        AppServerDynamicToolCallStatus::InProgress,
+        Vec::new(),
+        None,
+    );
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected a single history cell");
+    let combined = lines_to_single_string(&cells[0]);
+    assert_chatwidget_snapshot!("dynamic_tool_call_in_progress_history_snapshot", combined);
+}
+
+#[tokio::test]
 async fn exec_history_extends_previous_when_consecutive() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 

--- a/code-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/code-rs/tui/src/chatwidget/tests/helpers.rs
@@ -844,6 +844,57 @@ pub(super) fn handle_image_generation_end(
     );
 }
 
+pub(super) fn handle_dynamic_tool_call(
+    chat: &mut ChatWidget,
+    call_id: impl Into<String>,
+    namespace: Option<String>,
+    tool: impl Into<String>,
+    arguments: serde_json::Value,
+    content_items: Vec<AppServerDynamicToolCallOutputContentItem>,
+    success: bool,
+) {
+    handle_dynamic_tool_call_with_status(
+        chat,
+        call_id,
+        namespace,
+        tool,
+        arguments,
+        AppServerDynamicToolCallStatus::Completed,
+        content_items,
+        Some(success),
+    );
+}
+
+pub(super) fn handle_dynamic_tool_call_with_status(
+    chat: &mut ChatWidget,
+    call_id: impl Into<String>,
+    namespace: Option<String>,
+    tool: impl Into<String>,
+    arguments: serde_json::Value,
+    status: AppServerDynamicToolCallStatus,
+    content_items: Vec<AppServerDynamicToolCallOutputContentItem>,
+    success: Option<bool>,
+) {
+    chat.handle_server_notification(
+        ServerNotification::ItemCompleted(ItemCompletedNotification {
+            thread_id: thread_id(chat),
+            turn_id: "turn-1".to_string(),
+            completed_at_ms: 0,
+            item: AppServerThreadItem::DynamicToolCall {
+                id: call_id.into(),
+                namespace,
+                tool: tool.into(),
+                arguments,
+                status,
+                content_items: Some(content_items),
+                success,
+                duration_ms: Some(12),
+            },
+        }),
+        /*replay_kind*/ None,
+    );
+}
+
 pub(super) fn replay_user_message_inputs(
     chat: &mut ChatWidget,
     item_id: &str,

--- a/code-rs/tui/src/history_cell.rs
+++ b/code-rs/tui/src/history_cell.rs
@@ -47,6 +47,8 @@ use crate::wrapping::adaptive_wrap_line;
 use crate::wrapping::adaptive_wrap_lines;
 use base64::Engine;
 use codex_app_server_protocol::AskForApproval;
+use codex_app_server_protocol::DynamicToolCallOutputContentItem;
+use codex_app_server_protocol::DynamicToolCallStatus;
 use codex_app_server_protocol::McpAuthStatus;
 use codex_app_server_protocol::McpServerStatus;
 use codex_app_server_protocol::McpServerStatusDetail;
@@ -2003,6 +2005,158 @@ pub(crate) fn new_active_mcp_tool_call(
     McpToolCallCell::new(call_id, invocation, animations_enabled)
 }
 
+#[derive(Debug)]
+pub(crate) struct DynamicToolCallCell {
+    namespace: Option<String>,
+    tool: String,
+    arguments: serde_json::Value,
+    status: DynamicToolCallStatus,
+    content_items: Vec<DynamicToolCallOutputContentItem>,
+    success: Option<bool>,
+}
+
+impl DynamicToolCallCell {
+    fn completed(&self) -> bool {
+        matches!(
+            self.status,
+            DynamicToolCallStatus::Completed | DynamicToolCallStatus::Failed
+        )
+    }
+
+    fn invocation_line(&self) -> Line<'static> {
+        let args_str = serde_json::to_string(&self.arguments)
+            .unwrap_or_else(|_| self.arguments.to_string());
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        if let Some(namespace) = &self.namespace {
+            spans.push(namespace.clone().cyan());
+            spans.push(".".into());
+        }
+        spans.extend([
+            self.tool.clone().cyan(),
+            "(".into(),
+            args_str.dim(),
+            ")".into(),
+        ]);
+        spans.into()
+    }
+
+    fn rendered_content_lines(&self, width: usize) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        for item in &self.content_items {
+            match item {
+                DynamicToolCallOutputContentItem::InputText { text } => {
+                    let rendered =
+                        format_and_truncate_tool_result(text, TOOL_CALL_MAX_LINES, width);
+                    lines.extend(
+                        rendered
+                            .split('\n')
+                            .map(|segment| Line::from(segment.to_string())),
+                    );
+                }
+                DynamicToolCallOutputContentItem::InputImage { .. } => {
+                    lines.push(Line::from("<image content>"));
+                }
+            }
+        }
+        lines
+    }
+}
+
+impl HistoryCell for DynamicToolCallCell {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        let bullet = match (&self.status, self.success) {
+            (DynamicToolCallStatus::Failed, _) => "•".red().bold(),
+            (_, Some(false)) => "•".red().bold(),
+            (_, Some(true)) => "•".green().bold(),
+            _ => "•".dim(),
+        };
+        let header_text = match self.status {
+            DynamicToolCallStatus::InProgress => "Calling",
+            _ => "Called",
+        };
+
+        let invocation_line = self.invocation_line();
+        let mut compact_spans = vec![bullet, " ".into(), header_text.bold(), " ".into()];
+        let mut compact_header = Line::from(compact_spans.clone());
+        let reserved = compact_header.width();
+        let inline_invocation =
+            invocation_line.width() <= (width as usize).saturating_sub(reserved);
+
+        let mut lines = Vec::new();
+        if inline_invocation {
+            compact_header.extend(invocation_line.spans);
+            lines.push(compact_header);
+        } else {
+            compact_spans.pop();
+            lines.push(Line::from(compact_spans));
+
+            let opts = RtOptions::new((width as usize).saturating_sub(4))
+                .initial_indent("".into())
+                .subsequent_indent("    ".into());
+            let wrapped = adaptive_wrap_line(&invocation_line, opts);
+            let body_lines: Vec<Line<'static>> = wrapped.iter().map(line_to_static).collect();
+            lines.extend(prefix_lines(body_lines, "  └ ".dim(), "    ".into()));
+        }
+
+        let detail_wrap_width = (width as usize).saturating_sub(4).max(1);
+        let mut detail_lines = Vec::new();
+        for line in self.rendered_content_lines(detail_wrap_width) {
+            let line = Line::from(render_line_plain_text(&line).dim());
+            let wrapped = adaptive_wrap_line(
+                &line,
+                RtOptions::new(detail_wrap_width)
+                    .initial_indent("".into())
+                    .subsequent_indent("    ".into()),
+            );
+            detail_lines.extend(wrapped.iter().map(line_to_static));
+        }
+
+        if !detail_lines.is_empty() {
+            let initial_prefix: Span<'static> = if inline_invocation {
+                "  └ ".dim()
+            } else {
+                "    ".into()
+            };
+            lines.extend(prefix_lines(detail_lines, initial_prefix, "    ".into()));
+        }
+
+        lines
+    }
+
+    fn raw_lines(&self) -> Vec<Line<'static>> {
+        let header_text = if self.completed() { "Called" } else { "Calling" };
+        let invocation = render_line_plain_text(&self.invocation_line());
+        let mut lines = vec![Line::from(format!("{header_text} {invocation}"))];
+        lines.extend(self.rendered_content_lines(RAW_TOOL_OUTPUT_WIDTH));
+        lines
+    }
+}
+
+fn render_line_plain_text(line: &Line<'_>) -> String {
+    line.spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>()
+}
+
+pub(crate) fn new_dynamic_tool_call(
+    namespace: Option<String>,
+    tool: String,
+    arguments: serde_json::Value,
+    status: DynamicToolCallStatus,
+    content_items: Option<Vec<DynamicToolCallOutputContentItem>>,
+    success: Option<bool>,
+) -> DynamicToolCallCell {
+    DynamicToolCallCell {
+        namespace,
+        tool,
+        arguments,
+        status,
+        content_items: content_items.unwrap_or_default(),
+        success,
+    }
+}
+
 fn web_search_header(completed: bool) -> &'static str {
     if completed {
         "Searched"
@@ -3572,6 +3726,29 @@ mod tests {
 
     fn render_transcript(cell: &dyn HistoryCell) -> Vec<String> {
         render_lines(&cell.transcript_lines(u16::MAX))
+    }
+
+    #[test]
+    fn dynamic_tool_call_failed_status_renders_red_bullet() {
+        let cell = new_dynamic_tool_call(
+            None,
+            "code_bridge".to_string(),
+            serde_json::json!({"action":"collect"}),
+            DynamicToolCallStatus::Failed,
+            Some(vec![DynamicToolCallOutputContentItem::InputText {
+                text: "request failed".to_string(),
+            }]),
+            None,
+        );
+
+        let lines = cell.display_lines(80);
+        assert_eq!(
+            render_lines(&lines).join("\n"),
+            "• Called code_bridge({\"action\":\"collect\"})\n  └ request failed"
+        );
+        let bullet = lines[0].spans.first().expect("header starts with bullet");
+        assert_eq!(bullet.style.fg, Some(Color::Red));
+        assert!(bullet.style.add_modifier.contains(Modifier::BOLD));
     }
 
     fn assert_unstyled_lines(lines: &[Line<'static>]) {


### PR DESCRIPTION
## Summary

- Render app-server `DynamicToolCall` items in TUI history instead of dropping them.
- Add a generic dynamic tool history cell aligned with the existing MCP-style tool call display.
- Add chatwidget snapshots for Code Bridge `collect` text, Code Bridge `screenshot` image markers, namespaced tools, and in-progress dynamic calls, plus a direct failed-status style assertion.

## Validation

- `cargo test -p codex-tui dynamic_tool_call_ -- --nocapture`
- `cargo test -p codex-tui view_image_tool_call_adds_history_cell -- --nocapture`
- `cargo test -p codex-tui image_generation_call_adds_history_cell -- --nocapture`
- `git diff --check`
- `./build-fast.sh`

## Review

- Claude review requested focused namespace/status coverage; added namespace, in-progress, and failed-status tests.
- Gemini review timed out without actionable findings.
