### PR TITLE
Add Code Bridge navigate control fixture

### DIFF
--- a/code-rs/core/src/code_bridge.rs
+++ b/code-rs/core/src/code_bridge.rs
@@ -125,6 +125,8 @@ pub struct BridgeControlRequest {
     pub id: String,
     pub action: BridgeControlAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
@@ -136,6 +138,7 @@ pub struct BridgeControlRequest {
 #[serde(rename_all = "camelCase")]
 pub enum BridgeControlAction {
     Ping,
+    Navigate,
     Screenshot,
     Javascript,
 }
@@ -687,6 +690,7 @@ mod tests {
         let message = BridgeClientMessage::ControlRequest(BridgeControlRequest {
             id: "request-1".to_string(),
             action: BridgeControlAction::Javascript,
+            url: None,
             code: Some("location.href".to_string()),
             timeout_ms: Some(1_000),
             expect_result: Some(true),

--- a/code-rs/core/src/tools/handlers/code_bridge.rs
+++ b/code-rs/core/src/tools/handlers/code_bridge.rs
@@ -43,6 +43,7 @@ pub struct CodeBridgeHandler;
 enum CodeBridgeAction {
     Subscribe,
     Collect,
+    Navigate,
     Screenshot,
     Javascript,
 }
@@ -52,6 +53,8 @@ struct CodeBridgeArgs {
     action: CodeBridgeAction,
     #[serde(default)]
     level: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
     #[serde(default)]
     code: Option<String>,
     #[serde(default)]
@@ -110,10 +113,31 @@ impl ToolHandler for CodeBridgeHandler {
             CodeBridgeAction::Collect => {
                 collect(&turn.cwd, args.max_events, args.timeout_ms).await?
             }
+            CodeBridgeAction::Navigate => {
+                let Some(url) = args
+                    .url
+                    .map(|url| url.trim().to_string())
+                    .filter(|url| !url.is_empty())
+                else {
+                    return Err(FunctionCallError::RespondToModel(
+                        "code_bridge navigate action requires non-empty `url`".to_string(),
+                    ));
+                };
+                control(
+                    &turn.cwd,
+                    BridgeControlAction::Navigate,
+                    Some(url),
+                    None,
+                    args.timeout_ms,
+                    supports_image,
+                )
+                .await?
+            }
             CodeBridgeAction::Screenshot => {
                 control(
                     &turn.cwd,
                     BridgeControlAction::Screenshot,
+                    None,
                     None,
                     args.timeout_ms,
                     supports_image,
@@ -129,6 +153,7 @@ impl ToolHandler for CodeBridgeHandler {
                 control(
                     &turn.cwd,
                     BridgeControlAction::Javascript,
+                    None,
                     Some(code),
                     args.timeout_ms,
                     supports_image,
@@ -257,6 +282,7 @@ async fn collect(
 async fn control(
     cwd: &std::path::Path,
     action: BridgeControlAction,
+    url: Option<String>,
     code: Option<String>,
     timeout_ms: Option<u64>,
     supports_image: bool,
@@ -267,6 +293,7 @@ async fn control(
     let request = BridgeControlRequest {
         id: format!("code-bridge-{}", Utc::now().timestamp_millis()),
         action,
+        url,
         code,
         timeout_ms: Some(timeout_ms),
         expect_result: Some(true),
@@ -292,6 +319,7 @@ fn output_from_control(
         ok: outcome.ok,
         message: match action {
             BridgeControlAction::Ping => "Code Bridge ping completed".to_string(),
+            BridgeControlAction::Navigate => "Code Bridge navigation completed".to_string(),
             BridgeControlAction::Screenshot => "Code Bridge screenshot completed".to_string(),
             BridgeControlAction::Javascript => "Code Bridge JavaScript completed".to_string(),
         },
@@ -432,6 +460,7 @@ mod tests {
         let output = control(
             workspace.path(),
             BridgeControlAction::Javascript,
+            None,
             Some("window.location.href".to_string()),
             Some(2_000),
             false,
@@ -453,6 +482,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn navigate_control_sends_url_over_code_bridge_wire_shape() -> Result<()> {
+        let fake = FakeBridgeServer::start(FakeBridgeResponse::Navigate).await?;
+        let workspace = workspace_with_bridge_meta(&fake)?;
+        let target_url = "http://127.0.0.1:4321/local-navigation".to_string();
+
+        let output = control(
+            workspace.path(),
+            BridgeControlAction::Navigate,
+            Some(target_url.clone()),
+            None,
+            Some(2_000),
+            false,
+        )
+        .await?;
+        let observed = fake.wait().await?;
+
+        assert!(output.ok);
+        assert_eq!(output.delivered, Some(1));
+        assert_eq!(output.result, Some(json!({ "url": target_url })));
+        assert!(output.screenshot.is_none());
+        assert_eq!(observed.control["type"], "control_request");
+        assert_eq!(observed.control["action"], "navigate");
+        assert_eq!(observed.control["url"], target_url);
+        assert!(observed.control.get("code").is_none());
+        assert!(observed.control.get("method").is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn screenshot_control_returns_screenshot_summary() -> Result<()> {
         let fake = FakeBridgeServer::start(FakeBridgeResponse::Screenshot).await?;
         let workspace = workspace_with_bridge_meta(&fake)?;
@@ -460,6 +518,7 @@ mod tests {
         let output = control(
             workspace.path(),
             BridgeControlAction::Screenshot,
+            None,
             None,
             Some(2_000),
             false,
@@ -486,6 +545,7 @@ mod tests {
         let output = control(
             workspace.path(),
             BridgeControlAction::Screenshot,
+            None,
             None,
             Some(2_000),
             true,
@@ -546,6 +606,7 @@ mod tests {
                 [
                     json!("subscribe"),
                     json!("collect"),
+                    json!("navigate"),
                     json!("screenshot"),
                     json!("javascript"),
                 ]
@@ -619,6 +680,7 @@ mod tests {
     #[derive(Clone, Copy)]
     enum FakeBridgeResponse {
         Javascript,
+        Navigate,
         Screenshot,
         Events,
     }
@@ -680,6 +742,25 @@ mod tests {
                     ))
                     .await
                     .context("send javascript control result")?;
+            }
+            FakeBridgeResponse::Navigate => {
+                let url = control
+                    .get("url")
+                    .and_then(Value::as_str)
+                    .context("navigate control request should include url")?;
+                websocket
+                    .send(Message::Text(
+                        json!({
+                            "type": "control_result",
+                            "id": id,
+                            "ok": true,
+                            "result": { "url": url }
+                        })
+                        .to_string()
+                        .into(),
+                    ))
+                    .await
+                    .context("send navigate control result")?;
             }
             FakeBridgeResponse::Screenshot => {
                 websocket

--- a/code-rs/core/src/tools/handlers/code_bridge_spec.rs
+++ b/code-rs/core/src/tools/handlers/code_bridge_spec.rs
@@ -15,10 +15,14 @@ pub fn create_code_bridge_tool() -> ToolSpec {
                 vec![
                     json!("subscribe"),
                     json!("collect"),
+                    json!("navigate"),
                     json!("screenshot"),
                     json!("javascript"),
                 ],
-                Some("Required: subscribe, collect, screenshot, or javascript.".to_string()),
+                Some(
+                    "Required: subscribe, collect, navigate, screenshot, or javascript."
+                        .to_string(),
+                ),
             ),
         ),
         (
@@ -26,6 +30,12 @@ pub fn create_code_bridge_tool() -> ToolSpec {
             JsonSchema::string(Some(
                 "For action=subscribe: log level, one of errors, warn, info, or trace."
                     .to_string(),
+            )),
+        ),
+        (
+            "url".to_string(),
+            JsonSchema::string(Some(
+                "For action=navigate: URL to open in the bridge client.".to_string(),
             )),
         ),
         (
@@ -52,7 +62,7 @@ pub fn create_code_bridge_tool() -> ToolSpec {
 
     ToolSpec::Function(ResponsesApiTool {
         name: CODE_BRIDGE_TOOL_NAME.to_string(),
-        description: "Code Bridge local app telemetry/control. Subscribe to events, collect recent bridge events, request a screenshot, or run JavaScript on a connected bridge client.".to_string(),
+        description: "Code Bridge local app telemetry/control. Subscribe to events, collect recent bridge events, navigate a connected bridge client, request a screenshot, or run JavaScript.".to_string(),
         strict: false,
         defer_loading: None,
         parameters: JsonSchema::object(

--- a/code-rs/core/tests/suite/code_bridge.rs
+++ b/code-rs/core/tests/suite/code_bridge.rs
@@ -67,6 +67,7 @@ async fn fake_bridge_round_trip_covers_subscription_and_control_result() -> Resu
         BridgeControlRequest {
             id: "control-1".to_string(),
             action: BridgeControlAction::Ping,
+            url: None,
             code: None,
             timeout_ms: Some(1_000),
             expect_result: Some(true),
@@ -126,6 +127,7 @@ async fn fake_bridge_failed_control_result_is_returned_as_error() -> Result<()> 
         BridgeControlRequest {
             id: "control-1".to_string(),
             action: BridgeControlAction::Ping,
+            url: None,
             code: None,
             timeout_ms: Some(1_000),
             expect_result: Some(true),
@@ -138,6 +140,53 @@ async fn fake_bridge_failed_control_result_is_returned_as_error() -> Result<()> 
     let observed = fake.wait().await?;
     assert_eq!(observed.control["type"], "control_request");
     assert!(err.to_string().contains("bridge refused ping"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn fake_bridge_navigate_control_sends_url_without_remote_control_shape() -> Result<()> {
+    let fake = FakeBridgeServer::start(FakeBridgeMode::Control(FakeBridgeControlResponse::Success))
+        .await?;
+    let workspace = TempDir::new()?;
+    let code_dir = workspace.path().join(".code");
+    fs::create_dir(&code_dir)?;
+    fs::write(
+        code_dir.join(META_FILE),
+        serde_json::to_string(&json!({
+            "url": fake.url,
+            "secret": fake.secret,
+            "workspacePath": workspace.path(),
+            "heartbeatAt": chrono::Utc::now(),
+        }))?,
+    )?;
+    let navigate_url = "http://127.0.0.1/local-navigation".to_string();
+
+    let mut targets = discover_bridge_targets(workspace.path()).await?;
+    let target = targets.remove(0);
+    let subscription = load_subscription(workspace.path()).await?;
+    let outcome = request_control(
+        &target,
+        &subscription,
+        BridgeControlRequest {
+            id: "control-navigate".to_string(),
+            action: BridgeControlAction::Navigate,
+            url: Some(navigate_url.clone()),
+            code: None,
+            timeout_ms: Some(1_000),
+            expect_result: Some(true),
+        },
+        Duration::from_secs(2),
+    )
+    .await?;
+
+    let observed = fake.wait().await?;
+    assert_eq!(outcome.delivered, 1);
+    assert!(outcome.ok);
+    assert_eq!(observed.control["type"], "control_request");
+    assert_eq!(observed.control["action"], "navigate");
+    assert_eq!(observed.control["url"], navigate_url);
+    assert!(observed.control.get("code").is_none());
+    assert!(observed.control.get("method").is_none());
     Ok(())
 }
 
@@ -167,6 +216,7 @@ async fn fake_bridge_closed_connection_before_result_is_error() -> Result<()> {
         BridgeControlRequest {
             id: "control-1".to_string(),
             action: BridgeControlAction::Ping,
+            url: None,
             code: None,
             timeout_ms: Some(1_000),
             expect_result: Some(true),

--- a/docs/code-bridge-browser-parity.md
+++ b/docs/code-bridge-browser-parity.md
@@ -55,9 +55,11 @@ remote-control responses as the transport contract:
 | `screenshot` | mime type, byte length or data reference, page id, timestamp. |
 | `control` | request id, action, delivery/result status, optional response payload. |
 
-Control actions should start with `ping`, `screenshot`, and `javascript` because
-the old CLI and browser tool paths depended on those. Navigation can follow
-after local-page fixtures prove the lifecycle boundary.
+Control actions start with `ping`, `navigate`, `screenshot`, and `javascript`
+because the old CLI and browser tool paths depended on those. `navigate`
+travels over the bridge `control_request` channel with a `url` field and must
+return a `control_result`; any resulting `pageview` event is separate passive
+event evidence rather than the control acknowledgement itself.
 
 ## Validation Order
 
@@ -67,9 +69,10 @@ after local-page fixtures prove the lifecycle boundary.
    Desktop remote-control JSON-RPC path. The app-server path separation fixture
    landed in #417; core fake bridge fixtures landed in #418.
 2. Port the local navigation probe to the new overlay boundary using a local HTTP
-   server and no external network. First land bridge event fixtures for local
-   `pageview`, `console`, and `screenshot` payloads before reintroducing a
-   browser runtime.
+   server and no external network. Local bridge event fixtures for `pageview`,
+   `console`, and `screenshot` payloads landed in #419. Bridge `navigate`
+   control request fixtures landed after that event schema stabilized, still
+   without reintroducing the old browser crate.
 3. Add TUI snapshot coverage only after event schema and storage are stable.
 4. Wire implementation behind the additive Every Code bridge surface.
 


### PR DESCRIPTION
## Summary

- Add `navigate` to the existing additive Code Bridge control channel.
- Carry navigation targets through a `url` field on `control_request`, keeping Desktop `remoteControl/*` JSON-RPC shapes separate.
- Expose `action=navigate` through the model-facing `code_bridge` tool schema and update #399 boundary docs.
- Add fake bridge tests for handler and integration-level navigation control frames.

## Validation

- `cargo test -p codex-core code_bridge --lib -- --nocapture`
- `cargo test -p codex-core --test all code_bridge -- --nocapture`
- `git diff --check`
- `./build-fast.sh`

## Review

- Claude review: no blockers; accepted URL trim fix.
- Gemini/Antigravity review: no blockers; accepted URL trim fix and kept existing serde attribute style to avoid unrelated cleanup.
