### PR TITLE
Preserve Code Bridge evidence in compact prompt

### DIFF
--- a/code-rs/core/src/compact_tests.rs
+++ b/code-rs/core/src/compact_tests.rs
@@ -55,6 +55,22 @@ fn content_items_to_text_ignores_image_only_content() {
 }
 
 #[test]
+fn summarization_prompt_mentions_code_bridge_evidence_kinds() {
+    // Structural tripwire: behavioral preservation depends on collected bridge
+    // evidence being present in the transcript sent to the compacting model.
+    assert!(
+        SUMMARIZATION_PROMPT.contains("Code Bridge"),
+        "compact prompt should explicitly preserve collected bridge context"
+    );
+    for evidence_kind in ["console", "error", "pageview", "screenshot", "control"] {
+        assert!(
+            SUMMARIZATION_PROMPT.contains(evidence_kind),
+            "compact prompt should mention {evidence_kind} evidence"
+        );
+    }
+}
+
+#[test]
 fn collect_user_messages_extracts_user_text_only() {
     let items = vec![
         ResponseItem::Message {

--- a/code-rs/core/templates/compact/prompt.md
+++ b/code-rs/core/templates/compact/prompt.md
@@ -2,6 +2,7 @@ You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for
 
 Include:
 - Current progress and key decisions made
+- Important tool evidence, including collected Code Bridge console, error, pageview, screenshot, or control results
 - Important context, constraints, or user preferences
 - What remains to be done (clear next steps)
 - Any critical data, examples, or references needed to continue

--- a/docs/code-bridge-browser-parity.md
+++ b/docs/code-bridge-browser-parity.md
@@ -40,7 +40,7 @@ proves an additive extension is required:
 | `code-rs/cli/src/bridge.rs` | CLI-facing bridge discovery, event tailing, screenshot request, JavaScript request, and stale heartbeat handling. | Rewrite | CLI or harness fixtures with fake bridge metadata/server before restoring user commands. |
 | `code-rs/tui/src/chatwidget/browser_sessions.rs` and `code-rs/tui/src/history_cell/browser.rs` | TUI grouping and transcript rendering for browser/page events. | Rewrite | Snapshot fixtures against current TUI history/rendering once bridge event shape is defined. |
 | `vt100_chatwidget_snapshot__browser_session_*.snap` and `vt100_chatwidget_snapshot__context_cell_browser_badge.snap` | Browser-session grouping, unordered action stability, foreign-event filtering, and context badge visibility. | Rewrite | Current TUI snapshots after the additive bridge event schema exists. |
-| `code-rs/core/templates/compact/history_bridge.md` | Preserve bridge context during compaction. | Defer | Track under #399 after bridge event storage and transcript representation are defined. |
+| `code-rs/core/templates/compact/history_bridge.md` | Preserve handoff context during compaction. Despite the filename, this was a generic history handoff template, not a Code Bridge-specific artifact. | Retire | Keep the Codex-aligned programmatic compaction path. Preserve collected bridge evidence through the active compaction prompt and transcript summary instead of restoring the old template. |
 
 ## Proposed Additive Event Contract
 
@@ -74,7 +74,16 @@ event evidence rather than the control acknowledgement itself.
    control request fixtures landed after that event schema stabilized, still
    without reintroducing the old browser crate.
 3. Add TUI snapshot coverage only after event schema and storage are stable.
-4. Wire implementation behind the additive Every Code bridge surface.
+   Generic dynamic tool-call rendering and Code Bridge collect/screenshot
+   history snapshots landed in #422.
+4. Preserve bridge context through Codex-aligned compaction rather than
+   restoring the old generic `history_bridge.md` template. The active compact
+   prompt should ask the summarizing model to carry forward collected Code
+   Bridge console, error, pageview, screenshot, and control evidence when that
+   evidence is already present in the transcript. A later compaction fixture
+   should seed bridge tool results and assert the resulting summary carries the
+   important bridge findings forward.
+5. Wire implementation behind the additive Every Code bridge surface.
 
 Do not port the old browser crate, TUI cells, or CLI bridge commands wholesale
 before the relevant fixture in this document exists.


### PR DESCRIPTION
## Summary

- add Code Bridge console/error/pageview/screenshot/control evidence to the active compact prompt
- add a compact prompt tripwire test for the Code Bridge evidence kinds
- update the Code Bridge parity boundary to retire the old generic `history_bridge.md` template and keep compaction aligned with the current Codex programmatic path

## Validation

- `cargo test -p codex-core compact::tests::summarization_prompt_mentions_code_bridge_evidence_kinds --lib -- --nocapture`
- `git diff --check`
- `./build-fast.sh`

## Review

- Claude and Gemini/Antigravity reviewed the slice. I accepted the review feedback to rename the test and clarify that this is a prompt/transcript contract, not an end-to-end bridge compaction guarantee until bridge evidence is seeded through a compaction fixture.
