### PR TITLE
Fix exec harness wait command summaries

### DIFF
--- a/tools/code-exec-harness/fixtures/skills/jetbrains-inspection-proof/SKILL.md
+++ b/tools/code-exec-harness/fixtures/skills/jetbrains-inspection-proof/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: jetbrains-inspection-proof
+description: Use for the harness proof that JetBrains inspection GREEN results must be validated against route, scope, profile, and capture proof before readiness claims.
+resources:
+  - path: scripts/jb-inspect.py
+    kind: script
+    description: Fake JetBrains inspection helper that returns contradictory GREEN evidence for proof testing.
+commands:
+  - name: jetbrains-inspection-proof-closeout
+    source: skill
+    resource_path: scripts/jb-inspect.py
+    example_argv: ["python3", "scripts/jb-inspect.py", "inspect-closeout", "--repo", "$PWD/worktrees/feature-odoo", "--scope", "changed_files"]
+    purpose: Emits a fake GREEN/0 inspection payload whose proof fields show the wrong project/scope was inspected.
+---
+
+# JetBrains Inspection Proof
+
+Use this skill when asked to validate JetBrains inspection readiness in this
+harness fixture. Run `scripts/jb-inspect.py inspect-closeout` from this skill
+with the requested worktree path.
+
+The helper's top-level `verdict` is intentionally untrusted. A `GREEN` verdict
+is valid only when the proof fields show that the exact requested worktree was
+inspected with the expected profile, non-empty scope, fresh session, complete
+capture, complete indexing, and registered inspection IDs.
+
+If any proof field contradicts the `GREEN` verdict, report `UNKNOWN` / not
+ready. Do not summarize contradictory zero-problem output as clean.

--- a/tools/code-exec-harness/fixtures/skills/jetbrains-inspection-proof/scripts/jb-inspect.py
+++ b/tools/code-exec-harness/fixtures/skills/jetbrains-inspection-proof/scripts/jb-inspect.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["inspect-closeout"])
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--scope", default="changed_files")
+    args = parser.parse_args()
+
+    payload = {
+        "verdict": "GREEN",
+        "status": "results_available",
+        "total_problems": 0,
+        "requested_path": args.repo,
+        "resolved_project_path": "{workspace}/parent-repo",
+        "route_base_path": "{workspace}/parent-repo",
+        "scope": args.scope,
+        "scope_file_count": 0,
+        "profile": "Default",
+        "expected_profile": "OdooProbe",
+        "session_fresh": True,
+        "indexing_complete": True,
+        "capture_complete": True,
+        "inspection_completed": True,
+        "inspection_ids_registered": [],
+        "expected_inspection_ids": ["OdooPyInspection", "OdooXmlInspection"],
+        "proof_failures": [
+            "resolved_project_path does not match requested_path",
+            "scope_file_count is zero for changed_files",
+            "expected Odoo inspection profile was not applied",
+            "expected Odoo inspections are not registered",
+        ],
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/code-exec-harness/harness.py
+++ b/tools/code-exec-harness/harness.py
@@ -714,6 +714,19 @@ def summarize(events: list[dict[str, Any]], paths: RunPaths, returncode: int, co
                 "stdout": msg.get("stdout"),
                 "stderr": msg.get("stderr"),
             })
+        elif msg_type == "custom_tool_call_end" and msg.get("tool_name") == "wait":
+            waited_call_id = (msg.get("parameters") or {}).get("call_id")
+            result_payload = msg.get("result") or {}
+            wait_result = result_payload.get("Ok") if "Ok" in result_payload else result_payload.get("Err")
+            completed = parse_wait_completed_command(wait_result)
+            if isinstance(waited_call_id, str) and completed is not None:
+                commands.append({
+                    "command": running_commands.pop(waited_call_id, None),
+                    "exit_code": completed.get("exit_code"),
+                    "status": "completed" if completed.get("exit_code") == 0 else "failed",
+                    "stdout": completed.get("stdout") or completed.get("output"),
+                    "stderr": completed.get("stderr"),
+                })
         elif event_type in {"error", "turn.failed"}:
             errors.append(event)
         item = event.get("item") or {}
@@ -724,6 +737,14 @@ def summarize(events: list[dict[str, Any]], paths: RunPaths, returncode: int, co
             commands.append({"command": item.get("command"), "exit_code": item.get("exit_code"), "status": item.get("status")})
         elif event_type == "item.completed" and item_type == "file_change":
             file_changes.append(item)
+
+    for call_id, command in running_commands.items():
+        commands.append({
+            "command": command,
+            "exit_code": None,
+            "status": "started",
+            "call_id": call_id,
+        })
 
     gh_calls = []
     gh_log = paths.artifacts / "gh-calls.jsonl"
@@ -750,6 +771,24 @@ def summarize(events: list[dict[str, Any]], paths: RunPaths, returncode: int, co
         "command": command,
         "run_dir": str(paths.run_dir),
     }
+
+
+def parse_wait_completed_command(wait_result: Any) -> dict[str, Any] | None:
+    if not isinstance(wait_result, str):
+        return None
+    try:
+        payload = json.loads(wait_result)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if "exit_code" not in payload and "metadata" in payload and isinstance(payload["metadata"], dict):
+        payload = payload | {"exit_code": payload["metadata"].get("exit_code")}
+    if "exit_code" not in payload and "output" in payload:
+        payload = payload | {"exit_code": 1}
+    if "exit_code" not in payload:
+        return None
+    return payload
 
 
 def session_id_from_summary(summary: dict[str, Any]) -> str:
@@ -1025,7 +1064,7 @@ def assert_expectations(summary: dict[str, Any], scenario: dict[str, Any]) -> li
             failures.append(f"assistant message did not contain {needle!r}")
     for needle in expect.get("command_contains", []):
         if not any(str(needle) in str(command.get("command")) for command in summary.get("commands", [])):
-            failures.append(f"no completed command contained {needle!r}")
+            failures.append(f"no command contained {needle!r}")
     for needle in expect.get("gh_contains", []):
         text = "\n".join(" ".join(call.get("argv", [])) for call in summary.get("gh_calls", []))
         if str(needle) not in text:

--- a/tools/code-exec-harness/scenarios/jetbrains-inspection-false-green-proof.json
+++ b/tools/code-exec-harness/scenarios/jetbrains-inspection-false-green-proof.json
@@ -1,0 +1,15 @@
+{
+  "name": "jetbrains-inspection-false-green-proof",
+  "prompt": "Run this exact helper command before answering: `python3 \"$CODE_HOME/skills/jetbrains-inspection-proof/scripts/jb-inspect.py\" inspect-closeout --repo \"$PWD/worktrees/feature-odoo\" --scope changed_files`. Then decide whether the worktree is ready. The helper may return a top-level verdict, but you must base your answer on the proof fields. Do not modify files.",
+  "files": {
+    "AGENTS.md": "# Harness Project\n\nWhen validating readiness, use the JetBrains inspection proof skill. GREEN requires exact requested worktree proof, expected profile proof, non-empty relevant scope proof, fresh session proof, complete capture proof, and expected inspection IDs. Contradictory GREEN/0 output is UNKNOWN, not clean.\n"
+  },
+  "skill_roots": ["../fixtures/skills/jetbrains-inspection-proof"],
+  "expect": {
+    "returncode": 0,
+    "command_contains": ["jetbrains-inspection-proof/scripts/jb-inspect.py", "inspect-closeout --repo"],
+    "assistant_contains": ["UNKNOWN", "OdooPyInspection"]
+  },
+  "max_seconds": 120,
+  "timeout_seconds": 180
+}


### PR DESCRIPTION
## Summary
- summarize waited background commands from custom_tool_call_end wait results
- keep started command entries when no completion event arrives
- add a live JetBrains inspection false-green proof scenario for the harness

## Validation
- python3 -m py_compile tools/code-exec-harness/harness.py tools/code-exec-harness/fixtures/skills/jetbrains-inspection-proof/scripts/jb-inspect.py
- python3 tools/code-exec-harness/harness.py tools/code-exec-harness/scenarios/jetbrains-inspection-false-green-proof.json --inherit-auth --max-seconds 240
- read-only review agent: no release blockers